### PR TITLE
Fix nil pointer err for get kubernetes client

### DIFF
--- a/pisa-controller/pkg/kubernetes/client.go
+++ b/pisa-controller/pkg/kubernetes/client.go
@@ -36,6 +36,7 @@ func GetInClusterClient() (*KClient, error) {
 			initErr = err
 			return
 		}
+		client = &KClient{}
 		client.Client = clientset
 	})
 


### PR DESCRIPTION
### What is changed and how it works?

What's Changed:
1.  FIX nil pointer err for get kubernetes client





