### PR TITLE
refactor(configs): unified configs bewteen controller and proxy

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
       - name: openssl
         run: mkdir -p pisa-controller/build/certs && cd pisa-controller/build/certs && openssl req -new -SHA256 -newkey rsa:2048 -nodes -keyout tls.key -out tls.csr -subj "/C=CN/ST=beijing/L=beijing/O=/OU=/" && openssl x509 -req -sha256 -days 365 -in tls.csr -signkey tls.key -out tls.crt
       - name: "build"
-        run: cd pisa-controller && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-w -s" -gcflags "-N -l"  -o bin/controller cmd/main.go
+        run: cd pisa-controller && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-w -s" -gcflags "-N -l"  -o bin/controller cmd/pisa-controller/main.go
       - name: "Kaniko build"
         uses: aevea/action-kaniko@master
         with:

--- a/pisa-controller/pkg/kubernetes/types.go
+++ b/pisa-controller/pkg/kubernetes/types.go
@@ -15,8 +15,9 @@
 package kubernetes
 
 import (
-	"k8s.io/client-go/dynamic"
 	"time"
+
+	"k8s.io/client-go/dynamic"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -43,11 +44,11 @@ type DatabaseService struct {
 // DatabaseMySQL The type one of VirtualDatabase.Represents a virtual MySQL type
 type DatabaseMySQL struct {
 	Host     string `json:"host,omitempty"`
-	Port     string `json:"port,omitempty"`
-	Username string `json:"username,omitempty"`
+	Port     uint32 `json:"port,omitempty"`
+	User     string `json:"user,omitempty"`
 	Password string `json:"password,omitempty"`
 	DB       string `json:"db,omitempty"`
-	PoolSize int    `json:"poolSize,omitempty"`
+	PoolSize uint32 `json:"poolSize,omitempty"`
 }
 
 // VirtualDatabaseStatus defines the observed state of VirtualDatabase
@@ -102,8 +103,8 @@ type Database struct {
 // MySQL Configuration Definition
 type MySQL struct {
 	Host     string `json:"host"`
-	Port     string `json:"port"`
-	Username string `json:"username"`
+	Port     uint32 `json:"port"`
+	User     string `json:"user"`
 	Password string `json:"password"`
 	DB       string `json:"db"`
 }

--- a/pisa-controller/pkg/proxy/config.go
+++ b/pisa-controller/pkg/proxy/config.go
@@ -39,6 +39,7 @@ func GetConfig(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, err)
 		return
 	}
+
 	ctx.JSON(http.StatusOK, proxyConfig)
 }
 
@@ -103,7 +104,7 @@ func getConfig(client dynamic.Interface, namespace, appname string) (interface{}
 			proxy.BackendType = "mysql"
 			proxy.DB = service.DatabaseService.DatabaseMySQL.DB
 			proxy.Name = service.Name
-			proxy.Username = service.DatabaseService.DatabaseMySQL.Username
+			proxy.User = service.DatabaseService.DatabaseMySQL.User
 			proxy.Password = service.DatabaseService.DatabaseMySQL.Password
 			proxy.PoolSize = service.DatabaseService.DatabaseMySQL.PoolSize
 			proxy.ListenAddr = fmt.Sprintf("%s:%s", service.DatabaseService.DatabaseMySQL.Host, service.DatabaseService.DatabaseMySQL.Port)
@@ -116,7 +117,7 @@ func getConfig(client dynamic.Interface, namespace, appname string) (interface{}
 			if len(tsSpec.ConcurrencyControls) != 0 {
 				for _, control := range tsSpec.ConcurrencyControls {
 					// TODO: Convert CRD to configuration file json format.Need a better implementation
-					// ref: https://stackoverflow.com/questions/24613271/golang-is-conversion-between-different-struct-types-possible
+					// Ref: https://stackoverflow.com/questions/24613271/golang-is-conversion-between-different-struct-types-possible
 					proxy.Plugin.ConcurrencyControls = append(proxy.Plugin.ConcurrencyControls, *(*ConcurrencyControl)(&control))
 				}
 			}
@@ -134,9 +135,10 @@ func getConfig(client dynamic.Interface, namespace, appname string) (interface{}
 				proxyconfig.Mysql.Nodes = append(proxyconfig.Mysql.Nodes, Node{
 					Name:     dbe.GetName(),
 					Db:       dbeSpec.Database.MySQL.DB,
-					User:     dbeSpec.Database.MySQL.Username,
+					User:     dbeSpec.Database.MySQL.User,
 					Password: dbeSpec.Database.MySQL.Password,
-					Addr:     fmt.Sprintf("%s:%s", dbeSpec.Database.MySQL.Host, dbeSpec.Database.MySQL.Port),
+					Host:     dbeSpec.Database.MySQL.Host,
+					Port:     dbeSpec.Database.MySQL.Port,
 					Weight:   1,
 				})
 			}

--- a/pisa-controller/pkg/proxy/types.go
+++ b/pisa-controller/pkg/proxy/types.go
@@ -39,8 +39,8 @@ type Proxy struct {
 	ListenAddr        string            `json:"listen_addr"`
 	Name              string            `json:"name"`
 	Password          string            `json:"password"`
-	PoolSize          int               `json:"pool_size,omitempty"`
-	Username          string            `json:"username"`
+	PoolSize          uint32            `json:"pool_size,omitempty"`
+	User              string            `json:"user"`
 	SimpleLoadBalance SimpleLoadBalance `json:"simple_loadbalance"`
 	Plugin            Plugin            `json:"plugin"`
 }
@@ -71,6 +71,7 @@ type Node struct {
 	Db       string `json:"db"`
 	User     string `json:"user"`
 	Password string `json:"password"`
-	Addr     string `json:"addr"`
+	Host     string `json:"host"`
+	Port     uint32 `json:"port`
 	Weight   int    `json:"weight"`
 }

--- a/pisa-proxy/examples/example-config.toml
+++ b/pisa-proxy/examples/example-config.toml
@@ -16,7 +16,7 @@ user = "root"
 # proxy 认证密码
 password = "12345678"
 # proxy schema
-db = "test"
+db = "kubestar_test"
 # 配置后端数据源类型
 backend_type = "mysql"
 # proxy 与后端数据库建连连接池大小，值范围：1 ~ 255, 默认值：64
@@ -51,12 +51,14 @@ regex = "222"
 # 数据源 name
 name = "ds001"
 # database name
-db = "foo"
+db = "kubestar_test"
 # 数据库 user
 user = "root"
 # 数据库 password
-password = "12345678"
+password = "root"
 # 数据库地址
-addr = "127.0.0.1:3306"
+host = "127.0.0.1"
+# 数据库端口
+port = 3307
 # 负载均衡节点权重
 weight = 1

--- a/pisa-proxy/proxy/src/proxy.rs
+++ b/pisa-proxy/proxy/src/proxy.rs
@@ -100,7 +100,9 @@ pub struct MySQLNode {
     pub db: String,
     pub user: String,
     pub password: String,
+    #[serde(default = "default_mysql_node_host")]
     pub host: String,
+    #[serde(default = "default_mysql_node_port")]
     pub port: u32,
     pub weight: i64,
 }
@@ -110,7 +112,7 @@ fn default_auto_proxy_name() -> String {
 }
 
 fn default_auto_proxy_listen_addr() -> String {
-    "".into()
+    "0.0.0.0:3306".into()
 }
 
 fn default_auto_proxy_user() -> String {
@@ -139,6 +141,14 @@ fn default_auto_proxy_db() -> String {
 
 fn default_auto_balance_type() -> String {
     "random".into()
+}
+
+fn default_mysql_node_host() -> String {
+   "127.0.0.1".into() 
+}
+
+fn default_mysql_node_port() -> u32 {
+    3306
 }
 
 pub struct Proxy {

--- a/pisa-proxy/proxy/src/proxy.rs
+++ b/pisa-proxy/proxy/src/proxy.rs
@@ -100,7 +100,8 @@ pub struct MySQLNode {
     pub db: String,
     pub user: String,
     pub password: String,
-    pub addr: String,
+    pub host: String,
+    pub port: u32,
     pub weight: i64,
 }
 
@@ -172,7 +173,7 @@ impl Proxy {
                 Some(_) => {
                     let endpoint = Endpoint {
                         name: node.name,
-                        addr: node.addr,
+                        addr: format!("{}:{}", node.host, node.port),
                         db: node.db,
                         user: node.user,
                         password: node.password,


### PR DESCRIPTION
<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
- unified configs bewteen controll and proxy: rename username to user,  change type of port from string to uint32
- add golang build with subdirectory `pisa-controller`
- add default host `127.0.0.1` and port `3306` to default mysql node endpoint