### PR TITLE
fix(configs): fix serde json type of duration to u64 in pisa-proxy

### DIFF
--- a/pisa-proxy/plugin/src/config.rs
+++ b/pisa-proxy/plugin/src/config.rs
@@ -27,7 +27,7 @@ pub struct Plugin {
 pub struct ConcurrencyControl {
     pub regex: String,
     pub max_concurrency: u32,
-    #[serde_as(as = "serde_with::DurationSeconds<String>")]
+    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     pub duration: Duration,
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
- fix serde json type of duration in `concurrency_control` to `u64` for pisa-proxy