### PR TITLE
feat(readme，shortname): add short name for CRD,add readme

### DIFF
--- a/charts/pisa-controller/crds/core.database-mesh.io_databaseendpoints.yaml
+++ b/charts/pisa-controller/crds/core.database-mesh.io_databaseendpoints.yaml
@@ -29,6 +29,8 @@ spec:
     listKind: DatabaseEndpointList
     plural: databaseendpoints
     singular: databaseendpoint
+    shortNames:
+    - dbep
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/charts/pisa-controller/crds/core.database-mesh.io_trafficstrategies.yaml
+++ b/charts/pisa-controller/crds/core.database-mesh.io_trafficstrategies.yaml
@@ -29,6 +29,8 @@ spec:
     listKind: TrafficStrategyList
     plural: trafficstrategies
     singular: trafficstrategy
+    shortNames:
+      - ts
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/charts/pisa-controller/crds/core.database-mesh.io_virtualdatabases.yaml
+++ b/charts/pisa-controller/crds/core.database-mesh.io_virtualdatabases.yaml
@@ -29,6 +29,8 @@ spec:
     listKind: VirtualDatabaseList
     plural: virtualdatabases
     singular: virtualdatabase
+    shortNames:
+      - vdb
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/pisa-controller/README.md
+++ b/pisa-controller/README.md
@@ -4,8 +4,8 @@
 A Golang control plane designed for sidecar injection and configuration transformation.
 
 ## Feature
-### auto-injection
+### Auto-injection
 By labeling some resources in Kubernetes, Pisa-Controller can achieve automatic injection and start the Pisa-Proxy as a sidecar with application.
 
-## configuration management
+## Configuration management
 Use kubernetes CustomResourceDefinitions for configuration file matching and storage, and combine and deliver configuration files when the Pisa-Proxy starts.

--- a/pisa-controller/README.md
+++ b/pisa-controller/README.md
@@ -1,11 +1,11 @@
 # Introduction
 
 ## Pisa-Controller
-A Golang control plane designed for sidecar injection and configuration transformation
+A Golang control plane designed for sidecar injection and configuration transformation.
 
 ## Feature
 ### auto-injection
-By labeling some resources in Kubernetes, Pisa-Controller can achieve automatic injection and start the Pisa-Proxy as a sidecar with business programs
+By labeling some resources in Kubernetes, Pisa-Controller can achieve automatic injection and start the Pisa-Proxy as a sidecar with application.
 
 ## configuration management
-Use kubernetes CustomResourceDefinitions for configuration file matching and storage, and combine and deliver configuration files when the Pisa-Proxy starts
+Use kubernetes CustomResourceDefinitions for configuration file matching and storage, and combine and deliver configuration files when the Pisa-Proxy starts.

--- a/pisa-controller/README.md
+++ b/pisa-controller/README.md
@@ -1,2 +1,11 @@
 # Introduction
 
+## Pisa-Controller
+A Golang control plane designed for sidecar injection and configuration transformation
+
+## Feature
+### auto-injection
+By labeling some resources in Kubernetes, Pisa-Controller can achieve automatic injection and start the Pisa-Proxy as a sidecar with business programs
+
+## configuration management
+Use kubernetes CustomResourceDefinitions for configuration file matching and storage, and combine and deliver configuration files when the Pisa-Proxy starts

--- a/pisa-proxy/README.md
+++ b/pisa-proxy/README.md
@@ -1,1 +1,16 @@
-# Pisa-Proxy
+# Introduction
+
+## Pisa-Proxy
+A high performance Rust data plane used as SQL traffic proxy, support various of traffic governance capabilities.
+## Feature
+### Database traffic governance
+
+Applications access databases with SQL, so Pisanix will hijack all SQL traffic. This is a great opportunity to do a lot of things around traffic, like loadbalancing and SQL firewall.
+
+### Observability
+
+In the past, metrics could be retrieved from database instances and display in kinds of charts. Now with Pisanix, DBAs could have more chances to achieve better observability.
+
+### Progammable
+
+For DBAs who could and would like to solve problems with programming. Pisanix supports many kinds of plugin mechanism, like Lua and Wasm. People will have the chance to 'reshape' the expected behavior of databases.


### PR DESCRIPTION
### What is changed and how it works?

What's Changed:
- add short name for CRD : DatabaseEndpoint -> dbep,TrafficStrategy -> ts,VirtualDatabase -> vdb
- add readme for pisa-controller && pisa-proxy

