### PR TITLE
Refactor(protocol):  refactor client codec convert for mysql client protocol

### DIFF
--- a/pisa-proxy/Cargo.lock
+++ b/pisa-proxy/Cargo.lock
@@ -1640,6 +1640,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "pin-project",
+ "protocol_codegen",
  "rand 0.8.5",
  "rsa",
  "rust-crypto",
@@ -2148,11 +2149,11 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2231,6 +2232,17 @@ checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
  "bytes",
  "prost",
+]
+
+[[package]]
+name = "protocol_codegen"
+version = "0.1.0"
+dependencies = [
+ "mysql_protocol",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "tokio-util 0.7.1",
 ]
 
 [[package]]
@@ -3607,6 +3619,12 @@ name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-normalization"

--- a/pisa-proxy/Cargo.lock
+++ b/pisa-proxy/Cargo.lock
@@ -3171,13 +3171,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/pisa-proxy/protocol/codegen/Cargo.toml
+++ b/pisa-proxy/protocol/codegen/Cargo.toml
@@ -9,7 +9,7 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0"
-syn = { version = "1.0.72", features = ["full", "visit", "visit-mut", "extra-traits"] }
+syn = "1.0.96"
 proc-macro2 = "1.0.39"
 
 [dev-dependencies]

--- a/pisa-proxy/protocol/codegen/Cargo.toml
+++ b/pisa-proxy/protocol/codegen/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "protocol_codegen"
+version = "0.1.0"
+description = "Procedural macros for the protocol"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0"
+syn = { version = "1.0.72", features = ["full", "visit", "visit-mut", "extra-traits"] }
+proc-macro2 = "1.0.39"
+
+[dev-dependencies]
+tokio-util = { version = "0.7.0", features = ["full"] }
+mysql_protocol = { path = "../mysql" }

--- a/pisa-proxy/protocol/codegen/etc/license.template
+++ b/pisa-proxy/protocol/codegen/etc/license.template
@@ -1,1 +1,0 @@
-// Copyright {\d+} SphereEx Authors

--- a/pisa-proxy/protocol/codegen/etc/license.template
+++ b/pisa-proxy/protocol/codegen/etc/license.template
@@ -1,0 +1,1 @@
+// Copyright {\d+} SphereEx Authors

--- a/pisa-proxy/protocol/codegen/src/lib.rs
+++ b/pisa-proxy/protocol/codegen/src/lib.rs
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod auth;
-pub mod err;
-pub mod stmt;
+use proc_macro::TokenStream;
 
-pub mod codec;
-pub mod conn;
-pub mod resultset;
-pub mod stream;
-mod column;
+mod mysql_codec;
+
+#[proc_macro_derive(mysql_codec_convert)]
+pub fn derive_mysql_codec_convert(input: TokenStream) -> TokenStream {
+    mysql_codec::derive(input)
+}

--- a/pisa-proxy/protocol/codegen/src/mysql_codec.rs
+++ b/pisa-proxy/protocol/codegen/src/mysql_codec.rs
@@ -1,0 +1,112 @@
+// Copyright 2022 SphereEx Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use syn;
+
+// Codec needs to be reinitialize.
+fn codec_renew(ident: &Ident) -> TokenStream {
+    quote!(
+        Self::#ident(mut item) => {
+            item.codec_mut().renew();
+            item
+        },
+    )
+}
+
+// Convert codec, from src codec to dst codec.
+fn into_codec(src_ident: &Ident, dst_ident: &Ident) -> TokenStream {
+    if src_ident.to_string() == "ClientAuth" {
+        quote!(
+            Self::#src_ident(item) => item.map_codec(|codec| #dst_ident::with_auth_info(Some(codec))),
+        )
+    } else {
+        quote!(
+            Self::#src_ident(item) => item.map_codec(|codec| #dst_ident::with_auth_info(codec.auth_info)),
+        )
+    }
+}
+
+pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    // Define codec types.
+    // Tuple description (Enum variant, CodecType, whether need to be reinitialize)
+    let codecs: Vec<(Ident, Ident, bool)> = vec![
+        ("Resultset", "ResultsetCodec", true),
+        ("Stmt", "Stmt", true),
+        ("Common", "CommonCodec", false),
+        ("ClientAuth", "ClientAuth", false),
+    ]
+    .iter()
+    .map(|c| (Ident::new(c.0, Span::call_site()), Ident::new(c.1, Span::call_site()), c.2))
+    .collect();
+
+    let mut token_stream = TokenStream::new();
+
+    match input.data {
+        syn::Data::Enum(data) => {
+            for v in &data.variants {
+                let ident_string = v.ident.to_string().to_lowercase();
+                // Exclude ClientAuth.
+                if ident_string == "clientauth" {
+                    continue;
+                }
+
+                // Exclude current variant.
+                let filter_codecs = codecs.iter().filter(|c| c.0 != v.ident).collect::<Vec<_>>();
+                let curr_codec = codecs.iter().find(|c| c.0 == v.ident).unwrap();
+                let return_codec_name = &curr_codec.1;
+                
+                // Convert to TokenStream.
+                let mut codecs = filter_codecs
+                    .iter()
+                    .map(|c| into_codec(&c.0, &curr_codec.1))
+                    .collect::<Vec<_>>();
+
+                let func_name = Ident::new(&format!("into_{}", ident_string), Span::call_site());
+
+                let curr_codec = if !curr_codec.2 {
+                    into_codec(&curr_codec.0, &curr_codec.1)
+                } else {
+                    codec_renew(&curr_codec.0)
+                };
+
+                codecs.push(curr_codec);
+
+                let curr_token_stream = TokenStream::from_iter(codecs.into_iter());
+                let into_codec = quote! (
+                    pub fn #func_name(self) -> Framed<LocalStream, #return_codec_name> {
+                        match self {
+                            #curr_token_stream
+                        }
+                    }
+                );
+
+                token_stream.extend(into_codec);
+            }
+        }
+
+        _ => unreachable!(),
+    };
+
+    let ident = input.ident;
+    quote!(
+        impl #ident {
+            #token_stream
+        }
+    )
+    .into()
+}

--- a/pisa-proxy/protocol/codegen/tests/tests.rs
+++ b/pisa-proxy/protocol/codegen/tests/tests.rs
@@ -1,0 +1,43 @@
+// Copyright 2022 SphereEx Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use mysql_protocol::client::{
+    auth::ClientAuth,
+    codec::CommonCodec,
+    resultset::ResultsetCodec,
+    stmt::Stmt,
+    stream::{LocalStream, StreamWrapper},
+};
+use tokio_util::codec::Framed;
+
+#[macro_use]
+extern crate protocol_codegen;
+
+#[derive(mysql_codec_convert)]
+pub enum ClientCodec {
+    ClientAuth(Framed<LocalStream, ClientAuth>),
+    Resultset(Framed<LocalStream, ResultsetCodec>),
+    Stmt(Framed<LocalStream, Stmt>),
+    Common(Framed<LocalStream, CommonCodec>),
+}
+
+#[test]
+fn test_mysql_codec_convert() {
+    let stream = LocalStream::new(StreamWrapper::Plain(None));
+    let framed = Framed::new(stream, Stmt::new());
+    let stmt_codec = ClientCodec::Stmt(framed);
+    let common_codec = stmt_codec.into_common();
+    let res = format!("{:?}", common_codec);
+    assert!(res.contains("CommonCodec"))
+}

--- a/pisa-proxy/protocol/mysql/Cargo.toml
+++ b/pisa-proxy/protocol/mysql/Cargo.toml
@@ -33,3 +33,4 @@ num-traits = "0.2"
 num-derive = "0.3"
 async-trait = "0.1"
 conn_pool = { path = "../../proxy/pool" }
+protocol_codegen = { path = "../codegen" }

--- a/pisa-proxy/protocol/mysql/src/client/codec.rs
+++ b/pisa-proxy/protocol/mysql/src/client/codec.rs
@@ -22,6 +22,7 @@ use futures::Stream;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use pin_project::pin_project;
+use protocol_codegen::mysql_codec_convert;
 use tokio_util::codec::{Decoder, Encoder, Framed};
 
 use super::{
@@ -40,7 +41,6 @@ use crate::{
 
 pub type SendCommand<'a> = (u8, &'a str);
 
-use protocol_codegen::mysql_codec_convert;
 #[derive(Debug, mysql_codec_convert)]
 pub enum ClientCodec {
     ClientAuth(Framed<LocalStream, ClientAuth>),
@@ -357,8 +357,7 @@ mod test {
         let _ = driver.handshake().await;
 
         let query = "select user from mysql.user".as_bytes();
-        let mut stream =
-            driver.send_query(query).await.unwrap();
+        let mut stream = driver.send_query(query).await.unwrap();
 
         while let Some(data) = stream.next().await {
             assert_eq!(data.is_ok(), true);

--- a/pisa-proxy/protocol/mysql/src/client/codec.rs
+++ b/pisa-proxy/protocol/mysql/src/client/codec.rs
@@ -40,61 +40,13 @@ use crate::{
 
 pub type SendCommand<'a> = (u8, &'a str);
 
-#[derive(Debug)]
+use protocol_codegen::mysql_codec_convert;
+#[derive(Debug, mysql_codec_convert)]
 pub enum ClientCodec {
     ClientAuth(Framed<LocalStream, ClientAuth>),
     Resultset(Framed<LocalStream, ResultsetCodec>),
     Stmt(Framed<LocalStream, Stmt>),
     Common(Framed<LocalStream, CommonCodec>),
-}
-
-impl ClientCodec {
-    pub fn into_resultset(self) -> Framed<LocalStream, ResultsetCodec> {
-        match self {
-            Self::ClientAuth(item) => {
-                item.map_codec(|codec| ResultsetCodec::with_auth_info(Some(codec)))
-            }
-            Self::Resultset(mut item) => {
-                item.codec_mut().renew();
-                item
-            }
-            Self::Stmt(item) => {
-                item.map_codec(|codec| ResultsetCodec::with_auth_info(codec.auth_info))
-            }
-            Self::Common(item) => {
-                item.map_codec(|codec| ResultsetCodec::with_auth_info(codec.auth_info))
-            }
-        }
-    }
-
-    pub fn into_stmt(self) -> Framed<LocalStream, Stmt> {
-        match self {
-            Self::ClientAuth(item) => item.map_codec(|codec| Stmt::with_auth_info(Some(codec))),
-            Self::Resultset(item) => item.map_codec(|codec| Stmt::with_auth_info(codec.auth_info)),
-            Self::Stmt(mut item) => {
-                item.codec_mut().renew();
-                item
-            }
-            Self::Common(item) => item.map_codec(|codec| Stmt::with_auth_info(codec.auth_info)),
-        }
-    }
-
-    pub fn into_common(self) -> Framed<LocalStream, CommonCodec> {
-        match self {
-            Self::ClientAuth(item) => {
-                item.map_codec(|codec| CommonCodec::with_auth_info(Some(codec)))
-            }
-            Self::Resultset(item) => {
-                item.map_codec(|codec| CommonCodec::with_auth_info(codec.auth_info))
-            }
-            Self::Stmt(item) => {
-                item.map_codec(|codec| CommonCodec::with_auth_info(codec.auth_info))
-            }
-            Self::Common(item) => {
-                item.map_codec(|codec| CommonCodec::with_auth_info(codec.auth_info))
-            }
-        }
-    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed:
1. refactor client codec convert for mysql client protocol.
Use procedural macro to reduce duplication of `ClientCodec`  convert.
