### PR TITLE
fix(parser): fix global is None in ast when parsing  statements

### DIFF
--- a/pisa-proxy/parser/mysql/src/lex.rs
+++ b/pisa-proxy/parser/mysql/src/lex.rs
@@ -355,11 +355,13 @@ impl<'a> Scanner<'a> {
             let var_key = self.chars[self.pos..].iter().collect::<String>();
             match var_key.to_lowercase() {
                 k if k.starts_with("global.") => {
-                    self.next_n(7);
+                    lexemes.push(Ok(DefaultLexeme::new(T_GLOBAL, self.pos, 6)));
+                    self.next_n(6);
                 }
 
                 k if k.starts_with("session.") => {
-                    self.next_n(8);
+                    lexemes.push(Ok(DefaultLexeme::new(T_GLOBAL, self.pos, 7)));
+                    self.next_n(7);
                 }
                 _ => {}
             }
@@ -385,6 +387,10 @@ impl<'a> Scanner<'a> {
                     old_pos,
                     self.pos - old_pos + 1,
                 )));
+            }
+
+            '.' => {
+                lexemes.push(Ok(DefaultLexeme::new(T_DOT, self.pos, 1)));
             }
 
             ch if is_user_var_char(ch) => {

--- a/pisa-proxy/parser/mysql/src/parser.rs
+++ b/pisa-proxy/parser/mysql/src/parser.rs
@@ -115,10 +115,16 @@ mod test {
             //"set AUTOCOMMIT=1",
             //"SELECT w, SUM(w) OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) FROM t;",
             //"SHOW DATABASES LIKE 'ds%'",
-            "SHOW FULL tables FROM test like 't_%'",
-            "START TRANSACTION",
-            "COMMIT",
-            "ROLLBACK",
+            //"SHOW FULL tables FROM test like 't_%'",
+            //"START TRANSACTION",
+            //"COMMIT",
+            //"ROLLBACK",
+            //"set names utf8mb4",
+            //"SET character_set_connection = gbk;",
+            //"SET character_set_results = gbk;",
+            //"SET character_set_client = \"gbk\";",
+            "SET @@GLOBAL.character_set_client = gbk;",
+            "SET @@SESSION.character_set_client = gbk;",
         ];
 
         let p = Parser::new();


### PR DESCRIPTION
Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed:
1.  fix `global` is None in ast when parsing  `set @@global.` statements


