### PR TITLE
refactor(loadbalance):change loadbalance dynamic dispatch from dyn to enum

### DIFF
--- a/pisa-proxy/proxy/loadbalance/src/balance.rs
+++ b/pisa-proxy/proxy/loadbalance/src/balance.rs
@@ -86,10 +86,8 @@ impl LoadBalance for BalanceType {
 impl Balance {
     pub fn build_balance(&mut self, algorithm_name: AlgorithmName) -> BalanceType {
         match algorithm_name {
-            AlgorithmName::Random => return BalanceType::Random(RandomWeighted::default()),
-            AlgorithmName::RoundRobin => {
-                return BalanceType::RoundRobin(RoundRobinWeightd::default())
-            }
-        };
+            AlgorithmName::Random => BalanceType::Random(RandomWeighted::default()),
+            AlgorithmName::RoundRobin => BalanceType::RoundRobin(RoundRobinWeightd::default()),
+        }
     }
 }

--- a/pisa-proxy/proxy/loadbalance/src/balance.rs
+++ b/pisa-proxy/proxy/loadbalance/src/balance.rs
@@ -35,14 +35,61 @@ pub trait LoadBalance {
     fn remove_all(&mut self);
 }
 
-impl Balance {
-    pub fn build_balance(
-        &mut self,
-        algorithm_name: AlgorithmName,
-    ) -> Box<dyn LoadBalance + Send + Sync> {
-        match algorithm_name {
-            AlgorithmName::Random => Box::new(RandomWeighted::default()),
-            AlgorithmName::RoundRobin => Box::new(RoundRobinWeightd::default()),
+pub enum BalanceType {
+    Random(RandomWeighted),
+    RoundRobin(RoundRobinWeightd),
+}
+
+impl LoadBalance for BalanceType {
+    fn next(&mut self) -> Option<&Endpoint> {
+        match self {
+            BalanceType::Random(inner_random) => inner_random.next(),
+            BalanceType::RoundRobin(inner_roundrobin) => inner_roundrobin.next(),
         }
+    }
+
+    fn add(&mut self, endpoint: Endpoint) {
+        match self {
+            BalanceType::Random(inner_random) => inner_random.add(endpoint),
+            BalanceType::RoundRobin(inner_roundrobin) => inner_roundrobin.add(endpoint),
+        }
+    }
+
+    fn item_exists(&self, endpoint: &Endpoint) -> bool {
+        match self {
+            BalanceType::Random(inner_random) => inner_random.item_exists(endpoint),
+            BalanceType::RoundRobin(inner_roundrobin) => inner_roundrobin.item_exists(endpoint),
+        }
+    }
+
+    fn get_all(&mut self) -> &Vec<Endpoint> {
+        match self {
+            BalanceType::Random(inner_random) => inner_random.get_all(),
+            BalanceType::RoundRobin(inner_roundrobin) => inner_roundrobin.get_all(),
+        }
+    }
+    fn remove_item(&mut self, endpoint: Endpoint) {
+        match self {
+            BalanceType::Random(inner_random) => inner_random.remove_item(endpoint),
+            BalanceType::RoundRobin(inner_roundrobin) => inner_roundrobin.remove_item(endpoint),
+        }
+    }
+
+    fn remove_all(&mut self) {
+        match self {
+            BalanceType::Random(inner_random) => inner_random.remove_all(),
+            BalanceType::RoundRobin(inner_roundrobin) => inner_roundrobin.remove_all(),
+        }
+    }
+}
+
+impl Balance {
+    pub fn build_balance(&mut self, algorithm_name: AlgorithmName) -> BalanceType {
+        match algorithm_name {
+            AlgorithmName::Random => return BalanceType::Random(RandomWeighted::default()),
+            AlgorithmName::RoundRobin => {
+                return BalanceType::RoundRobin(RoundRobinWeightd::default())
+            }
+        };
     }
 }

--- a/pisa-proxy/proxy/src/proxy.rs
+++ b/pisa-proxy/proxy/src/proxy.rs
@@ -15,7 +15,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use endpoint::endpoint::Endpoint;
-use loadbalance::balance::{AlgorithmName, Balance, LoadBalance};
+use loadbalance::balance::{AlgorithmName, Balance, BalanceType, LoadBalance};
 use serde::{Deserialize, Serialize};
 use strategy::config::ReadWriteSplitting;
 use tokio::{
@@ -54,7 +54,7 @@ pub struct ProxyConfig {
     pub simple_loadbalance: Option<ProxySimpleLoadBalance>,
     pub plugin: Option<plugin::config::Plugin>,
     // read write splitting config structure
-    pub read_write_splitting: ReadWriteSplitting,
+    pub read_write_splitting: Option<ReadWriteSplitting>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -173,7 +173,7 @@ impl Proxy {
     pub fn build_loadbalance(
         &mut self,
         nodes: Vec<String>,
-    ) -> Result<Arc<Mutex<Box<dyn LoadBalance + Send + Sync>>>, std::io::Error> {
+    ) -> Result<Arc<Mutex<BalanceType>>, std::io::Error> {
         let mut balance = Balance {};
 
         let lb = match &self.app.simple_loadbalance {
@@ -193,6 +193,7 @@ impl Proxy {
                         password: node.password,
                         weight: node.weight,
                     };
+                    println!("{:#?}", endpoint);
                     balancer.add(endpoint);
                 }
                 _ => continue,

--- a/pisa-proxy/runtime/mysql/src/server/server.rs
+++ b/pisa-proxy/runtime/mysql/src/server/server.rs
@@ -19,7 +19,7 @@ use bytes::{Buf, BufMut, BytesMut};
 use common::ast_cache::ParserAstCache;
 use conn_pool::Pool;
 use futures::StreamExt;
-use loadbalance::balance::LoadBalance;
+use loadbalance::balance::BalanceType;
 use mysql_parser::{
     ast::{BeginStmt, SqlStmt},
     parser::{ParseError, Parser},
@@ -60,7 +60,7 @@ impl MySqlServer {
     pub async fn new(
         client: TcpStream,
         pool: Pool<ClientConn>,
-        lb: Arc<Mutex<Box<dyn LoadBalance + Send + Sync>>>,
+        lb: Arc<Mutex<BalanceType>>,
         proxy_config: ProxyConfig,
         parser: Arc<Parser>,
         ast_cache: Arc<plMutex<ParserAstCache>>,

--- a/pisa-proxy/runtime/mysql/src/transaction_fsm.rs
+++ b/pisa-proxy/runtime/mysql/src/transaction_fsm.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use conn_pool::{ConnAttr, Pool, PoolConn};
 use endpoint::endpoint::Endpoint;
-use loadbalance::balance::LoadBalance;
+use loadbalance::balance::{BalanceType, LoadBalance};
 use mysql_protocol::client::conn::ClientConn;
 use pisa_error::error::{Error, ErrorKind};
 use tokio::sync::Mutex;
@@ -51,7 +51,7 @@ pub enum TransEventName {
 pub trait ConnDriver {
     async fn get_driver_conn(
         &self,
-        loadbalance: Arc<Mutex<Box<dyn LoadBalance + Send + Sync>>>,
+        loadbalance: Arc<Mutex<BalanceType>>,
         pool: &mut Pool<ClientConn>,
     ) -> Result<(PoolConn<ClientConn>, Option<Endpoint>), Error>;
 }
@@ -63,7 +63,7 @@ pub struct Driver;
 impl ConnDriver for Driver {
     async fn get_driver_conn(
         &self,
-        loadbalance: Arc<Mutex<Box<dyn LoadBalance + Send + Sync>>>,
+        loadbalance: Arc<Mutex<BalanceType>>,
         pool: &mut Pool<ClientConn>,
     ) -> Result<(PoolConn<ClientConn>, Option<Endpoint>), Error> {
         let mut lb = loadbalance.clone().lock_owned().await;
@@ -226,7 +226,7 @@ pub struct TransFsm {
     pub events: Vec<TransEvent>,
     pub current_state: TransState,
     pub current_event: TransEventName,
-    pub lb: Arc<Mutex<Box<dyn LoadBalance + Send + Sync>>>,
+    pub lb: Arc<Mutex<BalanceType>>,
     pub pool: Pool<ClientConn>,
     pub client_conn: Option<PoolConn<ClientConn>>,
     pub endpoint: Option<Endpoint>,
@@ -234,10 +234,7 @@ pub struct TransFsm {
 }
 
 impl TransFsm {
-    pub fn new_trans_fsm(
-        lb: Arc<Mutex<Box<dyn LoadBalance + Send + Sync>>>,
-        pool: Pool<ClientConn>,
-    ) -> TransFsm {
+    pub fn new_trans_fsm(lb: Arc<Mutex<BalanceType>>, pool: Pool<ClientConn>) -> TransFsm {
         TransFsm {
             events: init_trans_events(),
             current_state: TransState::TransDummyState,


### PR DESCRIPTION
Signed-off-by: wangbo <wangbo@sphere-ex.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed:
- change loadbalance dynamic dispatch from dyn to enum
- add read write splitting config option

