### PR TITLE
fix(parser): fix parsing `identifer.identifer` failed

### DIFF
--- a/pisa-proxy/parser/mysql/src/lex.rs
+++ b/pisa-proxy/parser/mysql/src/lex.rs
@@ -641,9 +641,15 @@ impl<'a> Scanner<'a> {
             }
         });
 
-        self.is_ident_dot = self.peek() == '.';
-
         let ident_str = self.text[old_pos..self.pos].to_uppercase();
+
+        // Check whether has the `ident.ident` format.
+        if self.is_ident_dot {
+            self.pos -= 1;
+            return DefaultLexeme::new(T_IDENT, old_pos, ident_str.len());
+        }
+
+        self.is_ident_dot = self.peek() == '.';
 
         if ident_str.starts_with('_') {
             // check `UNDERSCORE_CHARSET` token

--- a/pisa-proxy/parser/mysql/src/lex.rs
+++ b/pisa-proxy/parser/mysql/src/lex.rs
@@ -902,7 +902,7 @@ mod test {
 
     #[test]
     fn test_scan_start_at() {
-        let inputs = vec![("@abc", 3), ("@@session.sss", 12)];
+        let inputs = vec![("@abc", 3), ("@@session.sss", 9)];
 
         for (input, pos) in inputs {
             let mut scanner = Scanner::new(input);

--- a/pisa-proxy/parser/mysql/src/parser.rs
+++ b/pisa-proxy/parser/mysql/src/parser.rs
@@ -125,6 +125,7 @@ mod test {
             //"SET character_set_client = \"gbk\";",
             //"SET @@GLOBAL.character_set_client = gbk;",
             //"SET @@SESSION.character_set_client = gbk;",
+            "SELECT * from mysql.select;",
             "create database if not exists db CHARACTER SET = utf8;",
         ];
 


### PR DESCRIPTION
Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed:
1. Fix parsing `identifer.identifer` failed when `.identifier` is keyword , like `select * from mysql.select`.
