### PR TITLE
fix(strategy):  Force forward readwrite backend when set autocommit=0

### DIFF
--- a/pisa-proxy/protocol/mysql/src/client/auth.rs
+++ b/pisa-proxy/protocol/mysql/src/client/auth.rs
@@ -83,6 +83,7 @@ pub struct ClientAuth {
     pub db: String,
     pub seq: u8,
     pub server_version: ServerVersion,
+    pub auotcommit: String,
 }
 
 impl ClientAuth {
@@ -102,6 +103,7 @@ impl ClientAuth {
             db: "".to_string(),
             seq: 0,
             server_version: ServerVersion::default(),
+            auotcommit: "".to_string(),
         }
     }
 

--- a/pisa-proxy/protocol/mysql/src/client/conn.rs
+++ b/pisa-proxy/protocol/mysql/src/client/conn.rs
@@ -218,6 +218,10 @@ impl ClientConn {
     pub fn set_charset(&mut self, name: &str) {
         self.framed.as_mut().unwrap().charset = name.to_string()
     }
+
+    pub fn set_autocommit(&mut self, status: &str) {
+        self.framed.as_mut().unwrap().auotcommit = status.to_string()
+    }
 }
 
 impl Clone for ClientConn {
@@ -282,6 +286,19 @@ impl ConnAttr for ClientConn {
                 None
             } else {
                 Some(codec.charset.clone())
+            }
+        } else {
+            None
+        }
+    }
+
+    fn get_autocommit(&self) -> Option<String> {
+        let codec = self.framed.as_ref();
+        if let Some(codec) = codec {
+            if codec.auotcommit.is_empty() {
+                None
+            } else {
+                Some(codec.auotcommit.clone())
             }
         } else {
             None

--- a/pisa-proxy/protocol/mysql/src/server/conn.rs
+++ b/pisa-proxy/protocol/mysql/src/server/conn.rs
@@ -59,6 +59,7 @@ pub struct Connection {
     pub db: String,
     pub affected_rows: i64,
     pub pkt: Packet,
+    pub autocommit: String,
     server_version: String,
 }
 
@@ -88,6 +89,7 @@ impl Connection {
             //pkt: Packet::new(Arc::new(Mutex::new(BufStream::new(socket)))),
             pkt: Packet::new(BufStream::new(LocalStream::from(socket))),
             server_version,
+            autocommit: "".to_string(),
         }
     }
 

--- a/pisa-proxy/proxy/pool/src/conn_pool.rs
+++ b/pisa-proxy/proxy/pool/src/conn_pool.rs
@@ -41,6 +41,8 @@ pub trait ConnAttr {
     fn get_db(&self) -> Option<String>;
     // Get current charset
     fn get_charset(&self) -> Option<String>;
+    // Get current autocommit status
+    fn get_autocommit(&self) -> Option<String>;
 }
 
 #[derive(Debug)]

--- a/pisa-proxy/proxy/strategy/src/readwritesplitting/static_rw.rs
+++ b/pisa-proxy/proxy/strategy/src/readwritesplitting/static_rw.rs
@@ -126,5 +126,9 @@ mod test {
         let input = RouteInput::Statement("select 1");
         let res = rws.dispatch(&input).unwrap();
         assert_eq!(res.0.unwrap().addr, "127.0.0.1");
+
+        let input = RouteInput::Transaction("begin");
+        let res = rws.dispatch(&input).unwrap();
+        assert_eq!(res.0.unwrap().addr, "127.0.0.2");
     }
 }

--- a/pisa-proxy/proxy/strategy/src/route.rs
+++ b/pisa-proxy/proxy/strategy/src/route.rs
@@ -30,6 +30,7 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
 #[non_exhaustive]
 pub enum RouteInput<'a> {
     Statement(&'a str),
+    Transaction(&'a str),
     None,
 }
 

--- a/pisa-proxy/runtime/mysql/src/server/server.rs
+++ b/pisa-proxy/runtime/mysql/src/server/server.rs
@@ -663,20 +663,6 @@ impl MySqlServer {
         self.client.pkt.conn.shutdown().await.map_err(ProtocolError::Io)
     }
 
-    async fn handle_trans_stmt<'a>(
-        &mut self,
-        client_conn: &'a mut PoolConn<ClientConn>,
-        input: &'a str,
-    ) -> Result<ResultsetStream<'a>, ProtocolError> {
-        if let Err(err) =
-            self.trans_fsm.trigger(TransEventName::StartEvent, RouteInput::Transaction(input)).await
-        {
-            error!("err: {:?}", err);
-        }
-
-        client_conn.send_query(input.as_bytes()).await
-    }
-
     fn get_ast(&mut self, sql: &str) -> Result<Vec<SqlStmt>, ParseError> {
         let mut ast_cache = self.ast_cache.lock();
         let try_ast = ast_cache.get(sql.to_string());

--- a/pisa-proxy/runtime/mysql/src/transaction_fsm.rs
+++ b/pisa-proxy/runtime/mysql/src/transaction_fsm.rs
@@ -289,7 +289,6 @@ impl TransFsm {
         state_name: TransEventName,
         input: RouteInput<'_>,
     ) -> Result<(), Error> {
-        println!("src state {:?}, evt {:?}", self.current_state, self.current_event);
         for event in &self.events {
             if event.name == state_name && event.src_state == self.current_state {
                 match event.src_state {

--- a/pisa-proxy/runtime/mysql/src/transaction_fsm.rs
+++ b/pisa-proxy/runtime/mysql/src/transaction_fsm.rs
@@ -237,6 +237,18 @@ fn init_trans_events() -> Vec<TransEvent> {
             dst_state: TransState::TransDummyState,
             driver: Some(Box::new(Driver)),
         },
+        TransEvent {
+            name: TransEventName::CommitRollBackEvent,
+            src_state: TransState::TransStartState,
+            dst_state: TransState::TransDummyState,
+            driver: Some(Box::new(Driver)),
+        },
+        TransEvent {
+            name: TransEventName::QueryEvent,
+            src_state: TransState::TransSetSessionState,
+            dst_state: TransState::TransDummyState,
+            driver: Some(Box::new(Driver)),
+        },
     ];
 }
 
@@ -250,6 +262,7 @@ pub struct TransFsm {
     pub endpoint: Option<Endpoint>,
     pub db: Option<String>,
     pub charset: String,
+    pub autocommit: String,
 }
 
 impl TransFsm {
@@ -267,6 +280,7 @@ impl TransFsm {
             endpoint: None,
             db: None,
             charset: String::from("utf8mb4"),
+            autocommit: String::from(""),
         }
     }
 
@@ -275,6 +289,7 @@ impl TransFsm {
         state_name: TransEventName,
         input: RouteInput<'_>,
     ) -> Result<(), Error> {
+        println!("src state {:?}, evt {:?}", self.current_state, self.current_event);
         for event in &self.events {
             if event.name == state_name && event.src_state == self.current_state {
                 match event.src_state {
@@ -299,6 +314,12 @@ impl TransFsm {
         Ok(())
     }
 
+    // when autocommit=0, should be reset fsm state
+    pub fn reset_fsm_state(&mut self) {
+        self.current_state = TransState::TransDummyState;
+        self.current_event = TransEventName::DummyEvent;
+    }
+
     // Set current db.
     pub fn set_db(&mut self, db: String) {
         self.db = Some(db)
@@ -307,6 +328,11 @@ impl TransFsm {
     // Set current charset
     pub fn set_charset(&mut self, name: String) {
         self.charset = name;
+    }
+
+    // Set current autocommit
+    pub fn set_autocommit(&mut self, status: String) {
+        self.autocommit = status
     }
 
     pub async fn get_conn(&mut self) -> Result<PoolConn<ClientConn>, Error> {
@@ -345,6 +371,15 @@ impl TransFsm {
         if Some(&self.charset) != conn.get_charset().as_ref() {
             conn.set_charset(&self.charset);
             conn.send_query_discard_result(&format!("SET NAMES {}", &self.charset))
+                .await
+                .map_err(ErrorKind::Protocol)?;
+        }
+
+        //set autocommit
+        if Some(&self.autocommit) != conn.get_autocommit().as_ref() {
+            conn.set_charset(&self.charset);
+            conn.set_autocommit(&self.autocommit);
+            conn.send_query_discard_result(&format!("SET AUTOCOMMIT = {}", &self.autocommit))
                 .await
                 .map_err(ErrorKind::Protocol)?;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Close #132 

What's Changed:
1.  Add  handling `set autocommit`, sql will force forward to readwrite backend when autocommit = 0 
2.  Add `autocommit` status for ConnAttr