### PR TITLE
fix(parse): fix can't parse `select * from test.test limit 1`

### DIFF
--- a/pisa-proxy/parser/mysql/src/lex.rs
+++ b/pisa-proxy/parser/mysql/src/lex.rs
@@ -628,7 +628,7 @@ impl<'a> Scanner<'a> {
 
         let old_pos = self.pos;
 
-        self.scan_until(false, |scanner| {
+        self.scan_until(false,  |scanner| {
             let ch = scanner.peek();
             match ch {
                 ch if ch.is_alphanumeric() => false,
@@ -636,6 +636,14 @@ impl<'a> Scanner<'a> {
                 ch if (ch as u32) >= 0x80 && (ch as u32) <= 0xFFFF => false,
 
                 '_' | '$' | '\\' | '\t' => false,
+
+                '.' => {
+                    // If is_ident_dot is true, continue scanning until there is an  exit condition.
+                    match scanner.is_ident_dot {
+                        true => false,
+                        false => true,
+                    }
+                },
 
                 _ => true,
             }
@@ -646,6 +654,8 @@ impl<'a> Scanner<'a> {
         // Check whether has the `ident.ident` format.
         if self.is_ident_dot {
             self.pos -= 1;
+            // reset is_ident_dot is false
+            self.is_ident_dot = false;
             return DefaultLexeme::new(T_IDENT, old_pos, ident_str.len());
         }
 

--- a/pisa-proxy/parser/mysql/src/parser.rs
+++ b/pisa-proxy/parser/mysql/src/parser.rs
@@ -91,42 +91,42 @@ mod test {
     #[test]
     fn test_dml_stmt() {
         let inputs = vec![
-            //"select mod(a+b, 4)+1",
-            //"select mod( year(a) - abs(weekday(a) + dayofweek(a)), 4) + 1",
-            //"select * from (with cte as (select * from t) select 1 union select * from t) qn",
-            //"select * from t where 1 > (with cte as (select * from t) select * from cte)",
-            //r#"select '\xc6\\' from `\xab`;"#,
-            //"select '啊';",
-            //r#"select '\xa5\\'"#,
-            //r#"select '''\xa5\\'"#,
-            //r#"select ```\xa5\\`"#,
-            //"select 'e\\'",
-            //"select * from t where id = ?",
-            //"update test set id = ?",
-            //"update test set a = 1, b = ?",
-            //// TODO FIX ME.
-            //// "delete from test where a = 1",
-            //"PREPARE stmt1 FROM 'SELECT SQRT(POW(?,2) + POW(?,2)) AS hypotenuse'",
-            //// TODO FIX ME.
-            //// "PREPARE stmt2 FROM @s",
-            //"DEALLOCATE PREPARE stmt2",
-            //"EXECUTE stmt2",
-            //"BEGIN WORK",
-            //"set AUTOCOMMIT=1",
-            //"SELECT w, SUM(w) OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) FROM t;",
-            //"SHOW DATABASES LIKE 'ds%'",
-            //"SHOW FULL tables FROM test like 't_%'",
-            //"START TRANSACTION",
-            //"COMMIT",
-            //"ROLLBACK",
-            // "set names utf8mb4",
-            //"SET character_set_connection = gbk;",
-            //"SET character_set_results = gbk;",
-            //"SET character_set_client = \"gbk\";",
-            //"SET @@GLOBAL.character_set_client = gbk;",
-            //"SET @@SESSION.character_set_client = gbk;",
+            "select mod(a+b, 4)+1",
+            "select mod( year(a) - abs(weekday(a) + dayofweek(a)), 4) + 1",
+            "select * from (with cte as (select * from t) select 1 union select * from t) qn",
+            "select * from t where 1 > (with cte as (select * from t) select * from cte)",
+            r#"select '\xc6\\' from `\xab`;"#,
+            "select '啊';",
+            r#"select '\xa5\\'"#,
+            r#"select '''\xa5\\'"#,
+            r#"select ```\xa5\\`"#,
+            "select 'e\\'",
+            "select * from t where id = ?",
+            "update test set id = ?",
+            "update test set a = 1, b = ?",
+            "delete from test where a = 1",
+            "PREPARE stmt1 FROM 'SELECT SQRT(POW(?,2) + POW(?,2)) AS hypotenuse'",
+            "PREPARE stmt2 FROM @s",
+            "DEALLOCATE PREPARE stmt2",
+            "EXECUTE stmt2",
+            "BEGIN WORK",
+            "set AUTOCOMMIT=1",
+            "SELECT w, SUM(w) OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) FROM t;",
+            "SHOW DATABASES LIKE 'ds%'",
+            "SHOW FULL tables FROM test like 't_%'",
+            "START TRANSACTION",
+            "COMMIT",
+            "ROLLBACK",
+             "set names utf8mb4",
+            "SET character_set_connection = gbk;",
+            "SET character_set_results = gbk;",
+            "SET character_set_client = \"gbk\";",
+            "SET @@GLOBAL.character_set_client = gbk;",
+            "SET @@SESSION.character_set_client = gbk;",
             "SELECT * from mysql.select;",
             "create database if not exists db CHARACTER SET = utf8;",
+            "select * from test.test limit 1",
+            "select * from test.1test limit 1",
         ];
 
         let p = Parser::new();
@@ -137,8 +137,8 @@ mod test {
                 Err(e) => {
                     println!("sql={:?} {:?}", input, e)
                 }
-                Ok(s) => {
-                    println!("{:#?}", s)
+                Ok(_stmt) => {
+                    //println!("{:#?}", s)
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Close #139  <!-- Associate issue that describes the problem the PR tries to solve. -->

What's Changed:
1. Fix parsing failed like statemet `select * from test.test limit 1`
2. Uncomment for statements  of unit test in the parser.