### PR TITLE
fix: rename serverVersion to server_version

### DIFF
--- a/pisa-controller/pkg/proxy/types.go
+++ b/pisa-controller/pkg/proxy/types.go
@@ -45,7 +45,7 @@ type Proxy struct {
 	SimpleLoadBalance  *SimpleLoadBalance  `json:"simple_loadbalance,omitempty"`
 	ReadWriteSplitting *ReadWriteSplitting `json:"read_write_splitting,omitempty"`
 	Plugin             Plugin              `json:"plugin,omitempty"`
-	ServerVersion      string              `json:"serverVersion"`
+	ServerVersion      string              `json:"server_version,omitempty"`
 }
 
 type Plugin struct {


### PR DESCRIPTION
Signed-off-by: wangbo <wangbo@sphere-ex.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

What's Changed:
- rename serverVersion to server_version to fix Pisa-Proxy can't parse config from Pisa-Controller.

