### PR TITLE
fix(protocol): fix the packet whether is EOF Packet

### DIFF
--- a/pisa-proxy/protocol/mysql/src/util.rs
+++ b/pisa-proxy/protocol/mysql/src/util.rs
@@ -188,7 +188,7 @@ pub fn length_encoded_string(data: &mut BytesMut) -> (Vec<u8>, bool) {
 // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basic_eof_packet.html
 #[inline]
 pub fn is_eof(data: &[u8]) -> bool {
-    data.len() < 9 && *unsafe { data.get_unchecked(4) } == EOF_HEADER
+    data.len() <= 9 && *unsafe { data.get_unchecked(4) } == EOF_HEADER
 }
 
 // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basic_ok_packet.html
@@ -323,7 +323,7 @@ mod test {
 
     #[test]
     fn test_is_eof_length_error() {
-        let data = [0x05, 0x00, 0x00, 0x05, 0xfe, 0x00, 0x00, 0x02, 0x00];
+        let data = [0x05, 0x00, 0x00, 0x05, 0xfe, 0x00, 0x00, 0x02, 0x00, 0x00];
         let result = is_eof(&data[..]);
         assert_eq!(result, false);
     }


### PR DESCRIPTION
Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

ref #160 

What's Changed:
1. fix the packet whether is EOF Packet.
If packet is a `EOF` packet, the length of payload is <= 5 by the captured packets analyzed as follows:
```
05 00 00 2a fe 00 00 02 00
```
@dongzl 