### PR TITLE
refactor(pool): optimize get_conn, use map instead of for loop

### DIFF
--- a/pisa-proxy/Cargo.lock
+++ b/pisa-proxy/Cargo.lock
@@ -495,6 +495,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "crossbeam-queue",
+ "dashmap",
  "futures",
  "tokio-stream",
  "tracing",
@@ -640,6 +641,18 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "hashbrown 0.12.1",
+ "lock_api",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -1083,6 +1096,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+
+[[package]]
 name = "headers"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,7 +1262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
  "serde",
 ]
 
@@ -1458,7 +1477,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8015d95cb7b2ddd3c0d32ca38283ceb1eea09b4713ee380bceb942d85a244228"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1895,7 +1914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.2",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -1914,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -3945,9 +3964,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -3958,33 +3977,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "winreg"

--- a/pisa-proxy/protocol/mysql/src/client/conn.rs
+++ b/pisa-proxy/protocol/mysql/src/client/conn.rs
@@ -352,22 +352,22 @@ mod test {
         let password = "123456".to_string();
         let addr = "127.0.0.1:13306".to_string();
 
-        let conn = ClientConn::with_opts(user, password, addr);
+        let conn = ClientConn::with_opts(user, password, addr.clone());
 
         let mut pool = Pool::new(3);
         pool.set_factory(conn);
 
-        assert_eq!(0, pool.len());
+        assert_eq!(0, pool.len(&addr));
 
         {
-            let mut conn = pool.get_conn().await.unwrap();
+            let mut conn = pool.get_conn_with_endpoint(&addr).await.unwrap();
             let res = conn.send_query("show databases".as_bytes()).await;
             let mut res = res.unwrap();
             loop {
                 match res.next().await {
                     Some(data) => match data {
                         Ok(data) => {
-                            println!("{:?}", data);
+                            println!("data {:?}", data);
                         }
 
                         Err(e) => {
@@ -386,6 +386,6 @@ mod test {
             assert_eq!("root", &conn.get_user());
         }
 
-        assert_eq!(1, pool.len());
+        assert_eq!(1, pool.len(&addr));
     }
 }

--- a/pisa-proxy/protocol/mysql/src/server/conn.rs
+++ b/pisa-proxy/protocol/mysql/src/server/conn.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::{
-    io::Error,
     str,
     sync::atomic::{AtomicU32, Ordering},
 };
@@ -23,7 +22,7 @@ use tokio::{io::BufStream, net::TcpStream};
 use tracing::debug;
 
 use super::{err::MySQLError, stream::LocalStream};
-use crate::{charset::*, err, err::ProtocolError, mysql_const::*, server::packet::Packet, util::*};
+use crate::{charset::*, err::ProtocolError, mysql_const::*, server::packet::Packet, util::*};
 
 lazy_static! {
     static ref CONNECTION_ID: AtomicU32 = AtomicU32::new(0);

--- a/pisa-proxy/protocol/mysql/src/util.rs
+++ b/pisa-proxy/protocol/mysql/src/util.rs
@@ -210,9 +210,12 @@ pub fn get_length(buf: &[u8]) -> usize {
 #[cfg(test)]
 mod test {
     use bytes::BytesMut;
-    use crate::util::{calc_caching_sha2password, calc_password, compare, get_length, is_eof, is_ok, length_encode_int, random_buf};
 
     use super::{length_encoded_string, BufExt};
+    use crate::util::{
+        calc_caching_sha2password, calc_password, compare, get_length, is_eof, is_ok,
+        length_encode_int, random_buf,
+    };
 
     #[test]
     fn test_random_buf() {
@@ -225,7 +228,10 @@ mod test {
         let scramble = [0x70, 0x69, 0x73, 0x61, 0x6e, 0x69, 0x78];
         let password = [0x31, 0x32, 0x33, 0x34, 0x35, 0x36];
         let calc_password = calc_password(&scramble[..], &password[..]);
-        let result = [139, 87, 122, 170, 122, 110, 60, 78, 2, 63, 208, 152, 19, 86, 207, 190, 178, 51, 61, 127];
+        let result = [
+            139, 87, 122, 170, 122, 110, 60, 78, 2, 63, 208, 152, 19, 86, 207, 190, 178, 51, 61,
+            127,
+        ];
         assert_eq!(calc_password, &result[..])
     }
 
@@ -234,7 +240,10 @@ mod test {
         let scramble = [0x70, 0x69, 0x73, 0x61, 0x6e, 0x69, 0x78];
         let password = [0x31, 0x32, 0x33, 0x34, 0x35, 0x36];
         let calc_password = calc_caching_sha2password(&scramble[..], &password[..]);
-        let result = [97, 231, 153, 111, 85, 161, 188, 166, 190, 240, 239, 147, 138, 193, 141, 190, 194, 120, 170, 210, 235, 241, 79, 175, 198, 189, 36, 193, 105, 166, 179, 173];
+        let result = [
+            97, 231, 153, 111, 85, 161, 188, 166, 190, 240, 239, 147, 138, 193, 141, 190, 194, 120,
+            170, 210, 235, 241, 79, 175, 198, 189, 36, 193, 105, 166, 179, 173,
+        ];
         assert_eq!(calc_password, &result[..])
     }
 

--- a/pisa-proxy/proxy/pool/Cargo.toml
+++ b/pisa-proxy/proxy/pool/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 crossbeam-queue = "0.3.5"
+dashmap = "5.3.4"
 tokio-stream = { version = "0.1" }
 futures = "0.3.21"
 tracing = "0.1.13"

--- a/pisa-proxy/runtime/mysql/src/server/server.rs
+++ b/pisa-proxy/runtime/mysql/src/server/server.rs
@@ -17,7 +17,7 @@ use std::{str, sync::Arc, time::SystemTime};
 use byteorder::{ByteOrder, LittleEndian};
 use bytes::{Buf, BufMut, BytesMut};
 use common::ast_cache::ParserAstCache;
-use conn_pool::{Pool, PoolConn};
+use conn_pool::Pool;
 use futures::StreamExt;
 use mysql_parser::{
     ast::{Expr, ExprOrDefault, SetOptValues, SetOpts, SqlStmt, Value},

--- a/pisa-proxy/runtime/mysql/src/transaction_fsm.rs
+++ b/pisa-proxy/runtime/mysql/src/transaction_fsm.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use conn_pool::{ConnAttr, ConnAttrMut, Pool, PoolConn};
+use conn_pool::{ConnAttrMut, Pool, PoolConn};
 use endpoint::endpoint::Endpoint;
 use mysql_protocol::client::conn::{ClientConn, SessionAttr};
 use pisa_error::error::{Error, ErrorKind};
@@ -95,7 +95,7 @@ impl ConnDriver for Driver {
 
         pool.set_factory(factory);
 
-        match pool.get_conn_with_opts(endpoint.addr.as_ref()).await {
+        match pool.get_conn_with_endpoint(endpoint.addr.as_ref()).await {
             Ok(client_conn) => Ok((client_conn, Some(endpoint.clone()))),
             Err(err) => Err(Error::new(ErrorKind::Protocol(err))),
         }
@@ -344,7 +344,7 @@ impl TransFsm {
         let addr = self.endpoint.as_ref().unwrap().addr.as_ref();
         match conn {
             Some(client_conn) => Ok(client_conn),
-            None => match self.pool.get_conn_with_opts(addr).await {
+            None => match self.pool.get_conn_with_endpoint(addr).await {
                 Ok(mut client_conn) => {
                     client_conn.init(self.build_conn_attrs()).await;
                     Ok(client_conn)


### PR DESCRIPTION

Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?


What's Changed:
1. optimize get_conn for conn pool, use map instead of for loop
2. cargo fmt, remove unused imports

