### PR TITLE
fix(runtime): add reset transaction fsm after get set names command

### DIFF
--- a/pisa-proxy/runtime/mysql/src/server/server.rs
+++ b/pisa-proxy/runtime/mysql/src/server/server.rs
@@ -503,10 +503,10 @@ impl MySqlServer {
                     if let Some(name) = &name.charset_name {
                         self.client.charset = name.clone();
                         self.trans_fsm.set_charset(name.clone());
-                        self.trans_fsm
-                            .trigger(TransEventName::SetSessionEvent, RouteInput::Statement(input))
-                            .await
-                            .unwrap();
+                        let _ = self
+                            .trans_fsm
+                            .reset_fsm_state(RouteInput::Statement(input))
+                            .await;
                         return;
                     }
                 }


### PR DESCRIPTION
Signed-off-by: wangbo <wangbo@sphere-ex.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed:
- add reset transaction fsm after get set command

