### PR TITLE
fix(protocol): fix auth failed when there is no autoswitch request

### DIFF
--- a/pisa-proxy/protocol/mysql/src/client/auth.rs
+++ b/pisa-proxy/protocol/mysql/src/client/auth.rs
@@ -319,12 +319,12 @@ impl ClientAuth {
         data: &mut BytesMut,
     ) -> Result<Option<BytesMut>, ProtocolError> {
         let length = get_length(data) as usize;
-        let _ = data.split_to(4);
 
-        match data[0] {
+        match data[4] {
             OK_HEADER => Ok(None),
 
-            MORE_DATA_HEADER => Ok(Some(data.split_to(length).split_off(1))),
+            // Exclude header 4 byte and 1 type byte, return remain data
+            MORE_DATA_HEADER => Ok(Some(data.split_to(4 + length).split_off(4 + 1))),
 
             EOF_HEADER => {
                 if data.is_empty() {
@@ -333,7 +333,8 @@ impl ClientAuth {
                     ));
                 }
 
-                let _ = data.split_to(1);
+                // Exclude header and 1 type byte
+                let _ = data.split_to(4 + 1);
                 let is_pos = data.iter().position(|&x| x == 0x00);
                 match is_pos {
                     Some(pos) => {


### PR DESCRIPTION
Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>


<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed:
1. fix auth failed when there is no autoswitch request
This is a hidden bug, before pr #170, check auth success methods is
incorrect, as follows:

```
let _ = data.split_to(4);
if data[0] == OK_HEADER && data.len() <= 7 {
        let _ = data.split();
        return Ok(Some(HandshakeDecoderReturn::AuthSuccess));
}
```
Before pr#170, If auth success, this bug caused the value of data is  [0, 0, 0, 2, 0, 0, 0],
After `data.split_to(4)`, the value of data is [0,0,0] , `data[0]`
equal to 0x00 exactly, so return `Ok`.

The correct value of data is [7, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0], After `data.split_to(4)`, the value of data should is [0, 0, 0, 2, 0, 0, 0],
Then can be used `is_ok` check whether auth success.
