### PR TITLE
Feat(parser): add show replica status sql parser.

### DIFF
--- a/pisa-proxy/parser/mysql/src/ast/dml.rs
+++ b/pisa-proxy/parser/mysql/src/ast/dml.rs
@@ -3162,3 +3162,22 @@ pub struct ShowCreateUserStmt {
     pub span: Span,
     pub user: User,
 }
+
+#[derive(Debug, Clone)]
+pub struct ShowReplicaStatusStmt {
+    pub span: Span,
+    pub replica: Replica,
+    pub opt_channel: Option<Channel>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Replica {
+    Slave,
+    Replica,
+}
+
+#[derive(Debug, Clone)]
+pub struct Channel {
+    pub span: Span,
+    pub channel: String,
+}

--- a/pisa-proxy/parser/mysql/src/ast/mod.rs
+++ b/pisa-proxy/parser/mysql/src/ast/mod.rs
@@ -52,6 +52,7 @@ pub enum SqlStmt {
     ShowPrivilegesStmt(Box<ShowDetailsStmt>),
     ShowProcesslistStmt(Box<ShowDetailsStmt>),
     ShowReplicasStmt(Box<ShowDetailsStmt>),
+    ShowReplicaStatusStmt(Box<ShowReplicaStatusStmt>),
     ShowCreateProcedureStmt(Box<ShowCreateSpStmt>),
     ShowCreateFunctionStmt(Box<ShowCreateSpStmt>),
     ShowCreateTriggerStmt(Box<ShowCreateSpStmt>),

--- a/pisa-proxy/parser/mysql/src/grammar.y
+++ b/pisa-proxy/parser/mysql/src/grammar.y
@@ -121,6 +121,7 @@ sql_stmt -> SqlStmt:
   | show_privileges_stmt { SqlStmt::ShowPrivilegesStmt($1) }
   | show_processlist_stmt { SqlStmt::ShowProcesslistStmt($1) }
   | show_replicas_stmt { SqlStmt::ShowReplicasStmt($1) }
+  | show_replica_status_stmt { SqlStmt::ShowReplicaStatusStmt($1) }
   | show_create_procedure_stmt { SqlStmt::ShowCreateProcedureStmt($1) }
   | show_create_function_stmt { SqlStmt::ShowCreateFunctionStmt($1) }
   | show_create_trigger_stmt { SqlStmt::ShowCreateTriggerStmt($1) }
@@ -6176,6 +6177,40 @@ show_replicas_stmt -> Box<ShowDetailsStmt>:
         Box::new(ShowDetailsStmt {
            span: $span,
         })
+    }
+;
+
+show_replica_status_stmt -> Box<ShowReplicaStatusStmt>:
+    'SHOW' replica 'STATUS' opt_channel
+    {
+        Box::new(ShowReplicaStatusStmt {
+           span: $span,
+           replica: $2,
+           opt_channel: $4,
+        })
+    }
+;
+
+replica -> Replica:
+       SLAVE       { Replica::Slave }
+     | REPLICA     { Replica::Replica }
+;
+
+opt_channel -> Option<Channel>:
+     /* empty */ { None }
+    | 'FOR' 'CHANNEL' TEXT_STRING_sys_nonewline
+    {
+        Some(Channel {
+            span: $span,
+            channel: $3,
+        })
+    }
+;
+
+TEXT_STRING_sys_nonewline -> String:
+    'TEXT_STRING'
+    {
+      String::from($lexer.span_str($1.as_ref().unwrap().span()))
     }
 ;
 

--- a/pisa-proxy/parser/mysql/src/parser.rs
+++ b/pisa-proxy/parser/mysql/src/parser.rs
@@ -151,7 +151,7 @@ mod test {
             "SHOW PROCESSLIST;",
             "SHOW FULL PROCESSLIST;",
             "SHOW SLAVE STATUS;",
-            "SHOW REPLICA STATUS FOR CHANNEL channel_name;",
+            "SHOW REPLICA STATUS FOR CHANNEL 'channel_name';",
         ];
 
         let p = Parser::new();

--- a/pisa-proxy/parser/mysql/src/parser.rs
+++ b/pisa-proxy/parser/mysql/src/parser.rs
@@ -150,6 +150,8 @@ mod test {
             "SHOW REPLICAS;",
             "SHOW PROCESSLIST;",
             "SHOW FULL PROCESSLIST;",
+            "SHOW SLAVE STATUS;",
+            "SHOW REPLICA STATUS FOR CHANNEL channel_name;",
         ];
 
         let p = Parser::new();


### PR DESCRIPTION
Signed-off-by: Zonglei Dong <dongzonglei@apache.org>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

ref: #61 <!-- Associate issue that describes the problem the PR tries to solve. -->

What's Changed:

### Related changes

- add show replica status sql parser.

https://github.com/mysql/mysql-server/blob/8.0/sql/sql_yacc.yy

```
TEXT_STRING_sys_nonewline:
          TEXT_STRING_sys
          {
            if (!strcont($1.str, "\n"))
              $$= $1;
            else
            {
              my_error(ER_WRONG_VALUE, MYF(0), "argument contains not-allowed LF", $1.str);
              MYSQL_YYABORT;
            }
          }
        ;
```

Rust implement:

```
TEXT_STRING_sys_nonewline -> String:
    'TEXT_STRING'
    {
      String::from($lexer.span_str($1.as_ref().unwrap().span()))
    }
;
```