### PR TITLE
refactor parsing resultset row 

### DIFF
--- a/pisa-proxy/protocol/mysql/src/client/codec.rs
+++ b/pisa-proxy/protocol/mysql/src/client/codec.rs
@@ -38,7 +38,7 @@ use crate::{
     mysql_const::{
         CLIENT_PROTOCOL_41, CLIENT_SESSION_TRACK, CLIENT_TRANSACTIONS, SERVER_SESSION_STATE_CHANGED,
     },
-    row::{Row, RowDataTyp},
+    row::{Row, RowData, RowDataTyp},
     util::{get_length, is_eof, length_encode_int, length_encoded_string},
 };
 

--- a/pisa-proxy/protocol/mysql/src/client/codec.rs
+++ b/pisa-proxy/protocol/mysql/src/client/codec.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::{
+    convert::From,
     ops::{Deref, DerefMut},
     pin::Pin,
     sync::Arc,
@@ -143,7 +144,7 @@ impl<'a, T: Row> QueryResultStream<'a, T> {
     }
 }
 
-impl<'a, T: Row + Clone + std::convert::From<bytes::BytesMut>> Stream for QueryResultStream<'a, T> {
+impl<'a, T: Row + Clone + From<bytes::BytesMut>> Stream for QueryResultStream<'a, T> {
     type Item = Result<RowDataTyp<T>, ProtocolError>;
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let me = self.project();

--- a/pisa-proxy/protocol/mysql/src/client/codec.rs
+++ b/pisa-proxy/protocol/mysql/src/client/codec.rs
@@ -16,7 +16,6 @@ use std::{
     convert::From,
     ops::{Deref, DerefMut},
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -35,7 +34,6 @@ use super::{
     stream::LocalStream,
 };
 use crate::{
-    column::ColumnInfo,
     err::ProtocolError,
     mysql_const::{
         CLIENT_PROTOCOL_41, CLIENT_SESSION_TRACK, CLIENT_TRANSACTIONS, SERVER_SESSION_STATE_CHANGED,
@@ -128,7 +126,6 @@ impl<'a> Stream for ResultsetStream<'a> {
 
 #[pin_project]
 pub struct QueryResultStream<'a, T: Row> {
-    column_info: Arc<[ColumnInfo]>,
     #[pin]
     rs: ResultsetStream<'a>,
     row_data: RowDataTyp<T>,
@@ -136,15 +133,14 @@ pub struct QueryResultStream<'a, T: Row> {
 
 impl<'a, T: Row> QueryResultStream<'a, T> {
     pub fn new(
-        column_info: Arc<[ColumnInfo]>,
         rs: ResultsetStream<'a>,
         row_data: RowDataTyp<T>,
     ) -> Self {
-        QueryResultStream { column_info, rs, row_data }
+        QueryResultStream { rs, row_data }
     }
 }
 
-impl<'a, T: Row + Clone + From<bytes::BytesMut>> Stream for QueryResultStream<'a, T> {
+impl<'a,  T: Row + Clone + From<bytes::BytesMut>> Stream for QueryResultStream<'a, T> {
     type Item = Result<RowDataTyp<T>, ProtocolError>;
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let me = self.project();
@@ -156,10 +152,10 @@ impl<'a, T: Row + Clone + From<bytes::BytesMut>> Stream for QueryResultStream<'a
                 }
 
                 let mut row_data = me.row_data.clone();
+                // Exclude header 4 bytes
                 data.advance(4);
                 row_data.with_buf(data.into());
                 Poll::Ready(Some(Ok(row_data)))
-                //Poll::Ready(Some(Ok(me.row_data)))
             }
 
             Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),

--- a/pisa-proxy/protocol/mysql/src/client/conn.rs
+++ b/pisa-proxy/protocol/mysql/src/client/conn.rs
@@ -12,25 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::net::SocketAddr;
-use std::sync::Arc;
+use std::{net::SocketAddr, sync::Arc};
 
 use async_trait::async_trait;
 use bytes::BytesMut;
-use futures::SinkExt;
 use conn_pool::{ConnAttr, ConnAttrMut, ConnLike};
+use futures::SinkExt;
 use tokio::net::TcpStream;
 use tokio_stream::StreamExt;
 use tokio_util::codec::Framed;
 
 use super::{
     auth::{handshake, ClientAuth},
-    codec::{ClientCodec, CommonStream, ResultsetStream},
+    codec::{ClientCodec, CommonStream, QueryResultStream, ResultsetStream},
     resultset::ResultSendCommand,
     stmt::Stmt,
     stream::{LocalStream, StreamWrapper},
 };
-use crate::{err::ProtocolError, mysql_const::*, util::length_encode_int, column::{Column, ColumnInfo}};
+use crate::{
+    column::{Column, ColumnInfo},
+    err::ProtocolError,
+    mysql_const::*,
+    row::{RowDataText, RowDataTyp},
+    util::length_encode_int,
+};
 
 #[derive(Debug, Default)]
 pub struct ClientConn {
@@ -203,7 +208,10 @@ impl ClientConn {
         Ok(CommonStream::new(self.framed.as_mut()))
     }
 
-    pub async fn query_result<'a>(&'a mut self, val: &'a [u8]) -> Result<Option<(Arc<[ColumnInfo]>, ResultsetStream<'a>)>, ProtocolError> {
+    pub async fn query_result<'a>(
+        &'a mut self,
+        val: &'a [u8],
+    ) -> Result<Option<QueryResultStream<'a, BytesMut>>, ProtocolError> {
         let mut stream = self.send_query(val).await?;
 
         let header = match stream.next().await {
@@ -237,8 +245,15 @@ impl ClientConn {
 
         let arc_col_info: Arc<[ColumnInfo]> = col_info.into_boxed_slice().into();
 
-
-        Ok(Some((arc_col_info, stream)))
+        let is_binary = stream.is_binary();
+        match is_binary {
+            false => {
+                let row_data_text = RowDataText::new(arc_col_info.clone(), BytesMut::new());
+                let row_data = RowDataTyp::Text(row_data_text);
+                Ok(Some(QueryResultStream::new(arc_col_info.clone(), stream, row_data)))
+            }
+            true => todo!(),
+        }
     }
 
     // Send query, but discard result
@@ -383,7 +398,7 @@ mod test {
     use conn_pool::*;
     use tokio_stream::StreamExt;
 
-    use crate::{client::conn::ClientConn, err::ProtocolError, util::is_eof, row::RowData};
+    use crate::{client::conn::ClientConn, err::ProtocolError, row::RowData};
 
     #[tokio::test]
     async fn pool() {
@@ -441,17 +456,9 @@ mod test {
         let query = "select user,host from mysql.user".as_bytes();
         let mut res = driver.query_result(query).await.unwrap().unwrap();
 
-        while let Some(mut data) = res.1.next().await {
-            if is_eof(&data.as_ref().unwrap()) {
-                break;
-            }
+        while let Some(data) = res.next().await {
+            let mut row = data.unwrap();
 
-            //let mut data = &data.as_mut().unwrap()[4..];
-            //let user = data.decode_row_with_idx::<String>(0);
-            
-            //let host = data.decode_row_with_idx::<String>(0);
-
-            let mut row = RowData::new(res.0.clone(), &data.as_mut().unwrap()[4..]);
             let user = row.decode_with_name::<String>("user");
             let host = row.decode_with_name::<String>("host");
 

--- a/pisa-proxy/protocol/mysql/src/client/conn.rs
+++ b/pisa-proxy/protocol/mysql/src/client/conn.rs
@@ -248,9 +248,9 @@ impl ClientConn {
         let is_binary = stream.is_binary();
         match is_binary {
             false => {
-                let row_data_text = RowDataText::new(arc_col_info.clone(), BytesMut::new());
+                let row_data_text = RowDataText::new(arc_col_info, BytesMut::new());
                 let row_data = RowDataTyp::Text(row_data_text);
-                Ok(Some(QueryResultStream::new(arc_col_info.clone(), stream, row_data)))
+                Ok(Some(QueryResultStream::new(stream, row_data)))
             }
             true => todo!(),
         }

--- a/pisa-proxy/protocol/mysql/src/column.rs
+++ b/pisa-proxy/protocol/mysql/src/column.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bytes::Buf;
+use bytes::{Buf, BytesMut};
 
 use crate::{mysql_const::ColumnType, util::BufExt};
 
@@ -104,7 +104,8 @@ pub trait Column: BufExt {
 }
 
 /// Implements Column for T.
-impl<T: AsRef<[u8]> + Buf> Column for T {}
+impl Column for &[u8] {}
+impl Column for BytesMut {}
 
 #[cfg(test)]
 mod test {

--- a/pisa-proxy/protocol/mysql/src/lib.rs
+++ b/pisa-proxy/protocol/mysql/src/lib.rs
@@ -21,6 +21,7 @@ mod row;
 pub mod server;
 pub mod util;
 mod value;
+mod macros;
 
 #[macro_use]
 extern crate lazy_static;

--- a/pisa-proxy/protocol/mysql/src/row.rs
+++ b/pisa-proxy/protocol/mysql/src/row.rs
@@ -59,7 +59,8 @@ pub trait Row: BufExt {
 impl Row for BytesMut {}
 impl Row for &[u8] {}
 
-pub trait RowData {
+pub trait RowData<T: Row> {
+    fn with_buf(&mut self, buf: T);
     fn decode_with_name<V: Value>(&mut self, name: &str) -> value::Result<V>;
 }
 
@@ -118,13 +119,12 @@ impl<T: Row> RowDataText<T> {
         let common = RowDataCommon::new(columns);
         RowDataText { common, buf }
     }
+}
 
+impl<T: Row> RowData<T> for RowDataText<T> {
     fn with_buf(&mut self, buf: T) {
         self.buf = buf;
     }
-}
-
-impl<T: Row> RowData for RowDataText<T> {
     // The method must be called in column order
     fn decode_with_name<V: Value>(&mut self, name: &str) -> value::Result<V> {
         self.buf.decode_row_with_idx::<V>(self.common.get_idx(name)?)

--- a/pisa-proxy/protocol/mysql/src/row.rs
+++ b/pisa-proxy/protocol/mysql/src/row.rs
@@ -108,6 +108,7 @@ impl RowDataCommon {
     }
 }
 
+// For ProtocolText::ResultsetRow
 #[derive(Debug, Clone)]
 pub struct RowDataText<T: Row> {
     common: RowDataCommon,

--- a/pisa-proxy/protocol/mysql/src/row.rs
+++ b/pisa-proxy/protocol/mysql/src/row.rs
@@ -68,28 +68,8 @@ pub enum RowDataTyp<T: Row> {
     Text(RowDataText<T>),
 }
 
-macro_rules! gen_row_data {
-    ($name:ident, $($var:ident($ty:ty)),*) => {
-        impl<T: Row>  $name<T> {
-            pub fn with_buf(&mut self, buf: T)  {
-                match self {
-                    $($name::$var(x) => x.with_buf(buf),)*
-                }
-            }
-        }
 
-        impl<T: Row> RowData for RowDataTyp<T> {
-
-            fn decode_with_name<V: Value>(&mut self, name: &str) -> value::Result<V> {
-                match self {
-                    $($name::$var(x) => x.decode_with_name(name),)*
-                }
-            }
-        }
-    }
-}
-
-gen_row_data!(RowDataTyp, Text(RowDataText));
+crate::gen_row_data!(RowDataTyp, Text(RowDataText));
 
 #[derive(Debug, Clone)]
 pub struct RowDataCommon {
@@ -147,25 +127,6 @@ impl<T: Row> RowDataText<T> {
 impl<T: Row> RowData for RowDataText<T> {
     // The method must be called in column order
     fn decode_with_name<V: Value>(&mut self, name: &str) -> value::Result<V> {
-        //let try_idx = self.columns.iter().position(|x| x.column_name == name);
-        //if try_idx.is_none() {
-        //    return Err(DecodeRowError::ColumnNotFound(name.to_string()).into());
-        //}
-
-        //let idx = try_idx.unwrap();
-
-        //if self.consumed_idx.contains(&idx) {
-        //    return Err(DecodeRowError::ColumnAlreadyConsumed(name.to_string()).into());
-        //}
-
-        //self.consumed_idx.push(idx);
-        //self.consumed_idx.sort_unstable();
-
-        //// Find all data less then idx in consumed_idx and save count.
-        //// The corrent idx should be minus lt_idx_count when `lt_idx_count > 0`.
-        //let lt_idx_count = self.consumed_idx.iter().filter(|x| *x < &idx).count();
-
-        //self.buf.unwrap().decode_row_with_idx::<V>(idx - lt_idx_count)
         self.buf.decode_row_with_idx::<V>(self.common.get_idx(name)?)
     }
 }

--- a/pisa-proxy/protocol/mysql/src/util.rs
+++ b/pisa-proxy/protocol/mysql/src/util.rs
@@ -153,7 +153,10 @@ pub trait BufExt: Buf {
     }
 }
 
-impl<T: AsRef<[u8]> + Buf> BufExt for T {}
+//impl<T: AsRef<[u8]> + Buf> BufExt for T {}
+impl BufExt for &[u8] {}
+
+impl BufExt for BytesMut {}
 
 pub trait BufMutExt: BufMut {
     fn put_lenc_int(&mut self, n: u64) {


### PR DESCRIPTION
<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
ref: #194 

What's Changed:
1. Split `RowData` method
`RowData` struct changed to a Trait to support parsing  `Text Protocol ResultsetRow` and `Binary Protocol Resultset Row`.
Add `RowDataText` struct to support parsing  `Text Protocol ResultsetRow`.
2. Add `QuestResultStream` for easy used.
