### PR TITLE
feat(pisa-proxy, protocol): add get_inner for local_stream to get underlying io

### DIFF
--- a/pisa-proxy/protocol/mysql/src/client/auth.rs
+++ b/pisa-proxy/protocol/mysql/src/client/auth.rs
@@ -732,8 +732,7 @@ mod test {
     async fn test_handshake_resp(codec: ClientAuth) -> bool {
         let addr = "127.0.0.1:13306";
         let sock = TcpStream::connect(addr).await.unwrap();
-        let stream_wrapper = StreamWrapper::from(sock);
-        let local_stream = LocalStream::new(stream_wrapper);
+        let local_stream = LocalStream::from(sock);
 
         //let mut auth_codec = ClientAuth::new();
 

--- a/pisa-proxy/protocol/mysql/src/client/codec.rs
+++ b/pisa-proxy/protocol/mysql/src/client/codec.rs
@@ -32,7 +32,7 @@ use super::{
     auth::ClientAuth,
     resultset::{write_command_binary, ResultsetCodec},
     stmt::Stmt,
-    stream::{LocalStream, StreamWrapper},
+    stream::LocalStream,
 };
 use crate::{
     err::ProtocolError,
@@ -87,10 +87,7 @@ impl ClientCodec {
             Self::Common(framed) => framed.get_ref(),
         };
 
-        let underly_io = match &local_stream.wrapper {
-            StreamWrapper::Plain(stream) => stream.as_ref().unwrap(),
-            StreamWrapper::Secure(stream) => stream.get_ref().get_ref().get_ref(),
-        };
+        let underly_io = local_stream.get_inner();
 
         let is_ready = underly_io.ready(Interest::READABLE | Interest::WRITABLE).await;
         match is_ready {

--- a/pisa-proxy/protocol/mysql/src/client/conn.rs
+++ b/pisa-proxy/protocol/mysql/src/client/conn.rs
@@ -27,7 +27,7 @@ use super::{
     codec::{ClientCodec, CommonStream, QueryResultStream, ResultsetStream},
     resultset::ResultSendCommand,
     stmt::Stmt,
-    stream::{LocalStream, StreamWrapper},
+    stream::LocalStream,
 };
 use crate::{
     column::{Column, ColumnInfo},
@@ -64,8 +64,7 @@ impl ClientConn {
         let sock = TcpStream::connect(&self.endpoint).await?;
         sock.set_nodelay(true).unwrap();
 
-        let stream_wrapper = StreamWrapper::from(sock);
-        let local_stream = LocalStream::new(stream_wrapper);
+        let local_stream = LocalStream::from(sock);
 
         let mut auth_codec = ClientAuth::new();
         auth_codec.user = self.user.clone();

--- a/pisa-proxy/protocol/mysql/src/client/stream.rs
+++ b/pisa-proxy/protocol/mysql/src/client/stream.rs
@@ -26,20 +26,21 @@ use tokio_native_tls::{native_tls::TlsConnector, TlsStream};
 
 use crate::err::ProtocolError;
 
-#[pin_project]
+#[pin_project(project=LSProj)]
 #[derive(Debug)]
-pub struct LocalStream {
-    pub wrapper: StreamWrapper,
+pub enum LocalStream {
+    Plain(Option<TcpStream>),
+    Secure(TlsStream<TcpStream>),
 }
 
 impl LocalStream {
-    pub fn new(wrapper: StreamWrapper) -> LocalStream {
-        LocalStream { wrapper }
-    }
+    //pub fn new(wrapper: StreamWrapper) -> LocalStream {
+    //    LocalStream { wrapper }
+    //}
 
     pub async fn close(&mut self) {
-        match self.wrapper {
-            StreamWrapper::Plain(ref mut stream) => {
+        match self {
+            Self::Plain(ref mut stream) => {
                 stream.take().unwrap();
             }
             _ => unreachable!(),
@@ -53,8 +54,8 @@ impl LocalStream {
             .use_sni(false)
             .build()?;
 
-        let wrapper = match self.wrapper {
-            StreamWrapper::Plain(ref mut try_plain) => {
+        match self {
+            Self::Plain(ref mut try_plain) => {
                 let connector = tokio_native_tls::TlsConnector::from(tlsconn);
                 let plain_stream = try_plain.take().unwrap();
 
@@ -63,13 +64,12 @@ impl LocalStream {
                     .await
                     .unwrap();
 
-                StreamWrapper::from(tls_stream)
+                LocalStream::from(tls_stream)
             }
 
             _ => unreachable!(),
         };
 
-        self.wrapper = wrapper;
         Ok(())
     }
 }
@@ -80,14 +80,14 @@ impl AsyncRead for LocalStream {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<Result<(), tokio::io::Error>> {
-        let this = self.project();
+        let mut this = self.project();
 
-        match this.wrapper {
-            StreamWrapper::Plain(ref mut stream) => {
+        match this {
+            LSProj::Plain(ref mut stream) => {
                 Pin::new(stream.as_mut().unwrap()).poll_read(cx, buf)
             }
 
-            StreamWrapper::Secure(ref mut stream) => Pin::new(stream).as_mut().poll_read(cx, buf),
+            LSProj::Secure(ref mut stream) => Pin::new(stream).as_mut().poll_read(cx, buf),
         }
     }
 }
@@ -98,56 +98,65 @@ impl AsyncWrite for LocalStream {
         cx: &mut Context,
         buf: &[u8],
     ) -> Poll<Result<usize, tokio::io::Error>> {
-        let this = self.project();
+        let mut this = self.project();
 
-        match this.wrapper {
-            StreamWrapper::Plain(ref mut stream) => {
+        match this {
+            LSProj::Plain(ref mut stream) => {
                 Pin::new(stream.as_mut().unwrap()).poll_write(cx, buf)
             }
 
-            StreamWrapper::Secure(ref mut stream) => Pin::new(stream).as_mut().poll_write(cx, buf),
+            LSProj::Secure(ref mut stream) => Pin::new(stream).as_mut().poll_write(cx, buf),
         }
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), tokio::io::Error>> {
-        let this = self.project();
+        let mut this = self.project();
 
-        match this.wrapper {
-            StreamWrapper::Plain(ref mut stream) => {
+        match this {
+            LSProj::Plain(ref mut stream) => {
                 Pin::new(stream.as_mut().unwrap()).poll_flush(cx)
             }
 
-            StreamWrapper::Secure(ref mut stream) => Pin::new(stream).as_mut().poll_flush(cx),
+            LSProj::Secure(ref mut stream) => Pin::new(stream).as_mut().poll_flush(cx),
         }
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), tokio::io::Error>> {
-        let this = self.project();
+        let mut this = self.project();
 
-        match this.wrapper {
-            StreamWrapper::Plain(ref mut stream) => {
+        match this {
+            LSProj::Plain(ref mut stream) => {
                 Pin::new(stream.as_mut().unwrap()).poll_shutdown(cx)
             }
 
-            StreamWrapper::Secure(ref mut stream) => Pin::new(stream).as_mut().poll_shutdown(cx),
+            LSProj::Secure(ref mut stream) => Pin::new(stream).as_mut().poll_shutdown(cx),
         }
     }
 }
 
-#[derive(Debug)]
-pub enum StreamWrapper {
-    Plain(Option<TcpStream>),
-    Secure(TlsStream<TcpStream>),
-}
-
-impl From<TcpStream> for StreamWrapper {
+impl From<TcpStream> for LocalStream {
     fn from(stream: TcpStream) -> Self {
-        StreamWrapper::Plain(Some(stream))
+        LocalStream::Plain(Some(stream))
     }
 }
 
-impl From<TlsStream<TcpStream>> for StreamWrapper {
+impl From<TlsStream<TcpStream>> for LocalStream {
     fn from(stream: tokio_native_tls::TlsStream<TcpStream>) -> Self {
-        StreamWrapper::Secure(stream)
+        LocalStream::Secure(stream)
     }
 }
+
+impl LocalStream {
+    pub fn get_inner(&self) -> &TcpStream {
+        match self {
+            Self::Plain(stream) => {
+                stream.as_ref().unwrap()
+            },
+
+            Self::Secure(stream) => {
+                stream.get_ref().get_ref().get_ref()
+            }
+        }
+    }
+}
+

--- a/pisa-proxy/protocol/mysql/src/server/stream.rs
+++ b/pisa-proxy/protocol/mysql/src/server/stream.rs
@@ -118,3 +118,17 @@ impl From<TlsStream<TcpStream>> for LocalStream {
         LocalStream::Secure(stream)
     }
 }
+
+impl LocalStream {
+    pub fn get_inner(&self) -> &TcpStream {
+        match self {
+            Self::Plain(stream) => {
+                stream.as_ref().unwrap()
+            },
+
+            Self::Secure(stream) => {
+                stream.get_ref().get_ref().get_ref()
+            }
+        }
+    }
+}


### PR DESCRIPTION


Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?


What's Changed:
Add get_inner for local_stream to get underlying io. Also, this pr is optimized for the client's LocalStream.
