### PR TITLE
chore(pisa-proxy, protocol): fix unit test failed, add ComType enum

### DIFF
--- a/pisa-proxy/protocol/mysql/src/client/auth.rs
+++ b/pisa-proxy/protocol/mysql/src/client/auth.rs
@@ -650,7 +650,7 @@ mod test {
     use super::{handshake, ClientAuth};
     use crate::client::{
         codec::ClientCodec,
-        stream::{LocalStream, StreamWrapper},
+        stream::LocalStream
     };
 
     #[test]

--- a/pisa-proxy/protocol/mysql/src/mysql_const.rs
+++ b/pisa-proxy/protocol/mysql/src/mysql_const.rs
@@ -80,6 +80,91 @@ iota! {
          ,COM_RESET_CONNECTION
 }
 
+#[allow(non_camel_case_types)]
+#[derive(Debug)]
+#[repr(u8)]
+pub enum ComType {
+    SLEEP,
+    QUIT,
+    INIT_DB,
+    QUERY,
+    FIELD_LIST,
+    CREATE_DB,
+    DROP_DB,
+    REFRESH,
+    SHUTDOWN,
+    STATISTICS,
+    PROCESS_INFO,
+    CONNECT,
+    PROCESS_KILL,
+    DEBUG,
+    PING,
+    TIME,
+    DELAYED_INSERT,
+    CHANGE_USER,
+    BINLOG_DUMP,
+    TABLE_DUMP,
+    CONNECT_OUT,
+    REGISTER_SLAVE,
+    STMT_PREPARE,
+    STMT_EXECUTE,
+    STMT_SEND_LONG_DATA,
+    STMT_CLOSE,
+    STMT_RESET,
+    SET_OPTION,
+    STMT_FETCH,
+    DAEMON,
+    BINLOG_DUMP_GTID,
+    RESET_CONNECTION,
+}
+
+impl From<u8> for ComType {
+    #[inline]
+    fn from(t: u8) -> ComType {
+        unsafe { std::mem::transmute::<u8, ComType>(t) }
+    }
+}
+
+impl AsRef<str> for ComType {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::SLEEP => "sleep",
+            Self::QUIT => "quit",
+            Self::INIT_DB => "init_db",
+            Self::QUERY => "query",
+            Self::FIELD_LIST => "field_list",
+            Self::CREATE_DB => "create_db",
+            Self::DROP_DB => "drop_db",
+            Self::REFRESH => "refresh",
+            Self::SHUTDOWN => "shutdown",
+            Self::STATISTICS => "statistics",
+            Self::PROCESS_INFO => "process_info",
+            Self::CONNECT => "connect",
+            Self::PROCESS_KILL => "process_kill",
+            Self::DEBUG => "debug",
+            Self::PING => "ping",
+            Self::TIME => "time",
+            Self::DELAYED_INSERT => "delayed_insert",
+            Self::CHANGE_USER => "change_user",
+            Self::BINLOG_DUMP => "binlog_dump",
+            Self::TABLE_DUMP => "table_dump",
+            Self::CONNECT_OUT => "connect_out",
+            Self::REGISTER_SLAVE => "register_slave",
+            Self::STMT_PREPARE => "stmt_prepare",
+            Self::STMT_EXECUTE => "stmt_execute",
+            Self::STMT_SEND_LONG_DATA => "stmt_send_long_data",
+            Self::STMT_CLOSE => "stmt_close",
+            Self::STMT_RESET => "stmt_reset",
+            Self::SET_OPTION => "set_option",
+            Self::STMT_FETCH => "stmt_fetch",
+            Self::DAEMON => "daemon",
+            Self::BINLOG_DUMP_GTID => "binlog_dump_gtid",
+            Self::RESET_CONNECTION => "reset_connection",
+        }
+    }
+}
+
 iota! {
     pub const CLIENT_LONG_PASSWORD: u32 = 1 << iota;
          ,CLIENT_FOUND_ROWS

--- a/pisa-proxy/protocol/mysql/src/server/auth.rs
+++ b/pisa-proxy/protocol/mysql/src/server/auth.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 SphereEx Authors
 //
-// Licensed under the Ap&ache License, Version 2.0 (the "License");
+// Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //

--- a/pisa-proxy/protocol/mysql/src/server/codec.rs
+++ b/pisa-proxy/protocol/mysql/src/server/codec.rs
@@ -113,20 +113,11 @@ impl Decoder for PacketCodec {
     }
 }
 
-impl Encoder<BytesMut> for PacketCodec {
+impl<I: AsRef<[u8]>> Encoder<I> for PacketCodec {
     type Error = ProtocolError;
 
-    fn encode(&mut self, item: BytesMut, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        self.encode_packet(&item, dst);
-        Ok(())
-    }
-}
-
-impl Encoder<&[u8]> for PacketCodec {
-    type Error = ProtocolError;
-
-    fn encode(&mut self, item: &[u8], dst: &mut BytesMut) -> Result<(), Self::Error> {
-        self.encode_packet(item, dst);
+    fn encode(&mut self, item: I, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        self.encode_packet(item.as_ref(), dst);
         Ok(())
     }
 }


### PR DESCRIPTION
Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed:
1.  Fix unit test failed for client auth.
2. Add ComType enum in mysql_const.
3. Add Encode<I> generics parameter for PacketCodec.
