### PR TITLE
fix(pisa-proxy, protocol): fix logic error for length_encode_int

### DIFF
--- a/pisa-proxy/protocol/mysql/src/client/resultset.rs
+++ b/pisa-proxy/protocol/mysql/src/client/resultset.rs
@@ -19,7 +19,7 @@ use super::{auth::ClientAuth, codec::*};
 use crate::{
     err::ProtocolError,
     mysql_const::ERR_HEADER,
-    util::{get_length, is_eof, is_ok, length_encode_int},
+    util::{get_length, is_eof, is_ok, BufExt},
 };
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -106,9 +106,10 @@ impl ResultsetCodec {
 
         self.next_state = DecodeResultsetState::ColumnInfo;
 
-        let payload = data.split_to(4 + length);
+        let mut payload = data.split_to(4 + length);
+        let _ = payload.split_to(4);
 
-        let (col, is_null, _) = length_encode_int(&payload[4..]);
+        let (col, is_null, _) = payload.get_lenc_int();
         self.col = col;
 
         (payload, is_null)

--- a/pisa-proxy/runtime/mysql/src/server/server.rs
+++ b/pisa-proxy/runtime/mysql/src/server/server.rs
@@ -587,7 +587,9 @@ impl MySQLServer {
             return Ok(());
         }
 
-        let (cols, ..) = length_encode_int(&header[4..]);
+        let _ = header.split_to(4);
+        
+        let (cols, ..) = header.get_lenc_int();
         // first clear buf
         self.buf.clear();
 


### PR DESCRIPTION


Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?


What's Changed:
1. Remove length_encode_int method.
2. Add get_lenc_int method to BufExt trait and fix logic error for length_encode_int before.

