### PR TITLE
fix(pisa-proxy, protocol): remove 4 byte header when use PacketSend::Encode

### DIFF
--- a/pisa-proxy/runtime/mysql/src/mysql.rs
+++ b/pisa-proxy/runtime/mysql/src/mysql.rs
@@ -275,7 +275,7 @@ where
                             String::from("There is no healthy backend to connect."),
                         ));
                         cx.framed
-                            .send(PacketSend::Encode(err_info.into_boxed_slice()))
+                            .send(PacketSend::Encode(err_info[4..].into()))
                             .await
                             .map_err(ErrorKind::from)?;
                         error!("exec command err: {:?}", err);
@@ -315,7 +315,7 @@ where
                 "08S01".as_bytes().to_vec(),
                 err.to_string(),
             ));
-            cx.framed.send(PacketSend::Encode(err_info.into_boxed_slice())).await.map_err(ErrorKind::from)?;
+            cx.framed.send(PacketSend::Encode(err_info[4..].into())).await.map_err(ErrorKind::from)?;
             return Ok(RespContext { ep: None, duration: now.elapsed() });
         }
 
@@ -328,14 +328,14 @@ where
             ComType::QUERY => S::query(cx, &payload).await,
             ComType::FIELD_LIST => S::field_list(cx, &payload).await,
             ComType::PING => {
-                cx.framed.send(PacketSend::Encode(ok_packet()[..].into())).await.map_err(ErrorKind::from)?;
+                cx.framed.send(PacketSend::Encode(ok_packet()[4..].into())).await.map_err(ErrorKind::from)?;
                 return Ok(RespContext { ep: None, duration: now.elapsed() });
             }
             ComType::STMT_PREPARE => S::prepare(cx, &payload).await,
             ComType::STMT_EXECUTE => S::execute(cx, &payload).await,
             ComType::STMT_CLOSE => S::stmt_close(cx, &payload).await,
             ComType::STMT_RESET => {
-                cx.framed.send(PacketSend::Encode(ok_packet()[..].into())).await.map_err(ErrorKind::from)?;
+                cx.framed.send(PacketSend::Encode(ok_packet()[4..].into())).await.map_err(ErrorKind::from)?;
                 return Ok(RespContext { ep: None, duration: now.elapsed() });
             }
             x => {
@@ -344,7 +344,7 @@ where
                     "08S01".as_bytes().to_vec(),
                     format!("command {} not support", x.as_ref()),
                 ));
-                cx.framed.send(PacketSend::Encode(err_info.into_boxed_slice())).await.map_err(ErrorKind::from)?;
+                cx.framed.send(PacketSend::Encode(err_info[4..].into())).await.map_err(ErrorKind::from)?;
                 return Ok(RespContext { ep: None, duration: now.elapsed() });
             }
         }

--- a/pisa-proxy/runtime/mysql/src/server/server.rs
+++ b/pisa-proxy/runtime/mysql/src/server/server.rs
@@ -80,7 +80,7 @@ where
 
         if res.1 {
             req.framed
-                .send(PacketSend::Encode(ok_packet()[..].into()))
+                .send(PacketSend::Encode(ok_packet()[4..].into()))
                 .await
                 .map_err(ErrorKind::from)?;
         } else {


### PR DESCRIPTION


Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?


What's Changed:
1. Remove 4 byte header when use PacketSend::Encode to send.