### PR TITLE
fix(pisa-proxy,parser): fix incorrect when format PARTATION and LIMIT

### DIFF
--- a/pisa-proxy/parser/mysql/src/ast/dml.rs
+++ b/pisa-proxy/parser/mysql/src/ast/dml.rs
@@ -888,10 +888,14 @@ impl SingleTable {
     pub fn format(&self) -> String {
         let mut single = vec![
             self.table_name.clone(),
-            "PARTITION (".to_string(),
-            self.partition_names.join(","),
-            ")".to_string(),
+
         ];
+
+        if !self.partition_names.is_empty() {
+            single.push("PARTITION (".to_string());
+            single.push(self.partition_names.join(","));
+            single.push(")".to_string());
+        }
 
         if let Some(name) = &self.alias_name {
             single.push("AS".to_string());
@@ -1418,6 +1422,7 @@ pub struct LimitClause {
 impl LimitClause {
     pub fn format(&self) -> String {
         let mut clause = Vec::with_capacity(self.opts.len() + 1);
+        clause.push("LIMIT".to_string());
         clause.push(self.opts[0].to_string());
 
         if self.offset {


### PR DESCRIPTION
Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed:
1.  Fix incorrect when format PARTATION and LIMIT.
