### PR TITLE
feat(pisa-proxy, protocol): add encode for ok packet

### DIFF
--- a/pisa-proxy/protocol/mysql/src/client/auth.rs
+++ b/pisa-proxy/protocol/mysql/src/client/auth.rs
@@ -252,7 +252,7 @@ impl ClientAuth {
 
         // length-encode-integer
         let mut auth_resp_length_integer = Vec::with_capacity(9);
-        auth_resp_length_integer.put_lenc_int(auth_data.len() as u64);
+        auth_resp_length_integer.put_lenc_int(auth_data.len() as u64, false);
 
         //append_length_encoded_integer1(&mut auth_resp_length_integer, auth_data.len() as u64);
 

--- a/pisa-proxy/protocol/mysql/src/server/auth.rs
+++ b/pisa-proxy/protocol/mysql/src/server/auth.rs
@@ -473,14 +473,12 @@ pub async fn handshake(
 mod test {
     use bytes::BytesMut;
     use futures::{SinkExt, StreamExt};
-    use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
     use tokio_util::codec::Framed;
 
     use crate::{
         err::ProtocolError,
         server::{
             auth::{ServerHandshakeCodec, ServerHandshakeStatus},
-            codec::PacketCodec,
         },
     };
 
@@ -493,7 +491,7 @@ mod test {
         let server_version = "5.7.36".to_string();
         let hs = ServerHandshakeCodec::new(user, password, db, server_version);
 
-        let (mut client, mut server) = tokio::io::duplex(512);
+        let (client, server) = tokio::io::duplex(512);
         let mut framed = Framed::new(client, hs);
 
         let client_reponse_data = [
@@ -512,10 +510,9 @@ mod test {
             0x66, 0x6f, 0x72, 0x6d, 0x06, 0x78, 0x38, 0x36, 0x5f, 0x36, 0x34,
         ];
 
-        framed.send(BytesMut::from(&client_reponse_data[..])).await;
+        let _ = framed.send(BytesMut::from(&client_reponse_data[..])).await;
 
         let mut parts = framed.into_parts();
-        client = parts.io;
         parts.io = server;
 
         framed = Framed::from_parts(parts);
@@ -554,14 +551,14 @@ mod test {
             0x38, 0x36, 0x5f, 0x36, 0x34,
         ];
 
-        framed.send(BytesMut::from(&client_reponse_data[..])).await;
+        let _ = framed.send(BytesMut::from(&client_reponse_data[..])).await;
 
         let mut parts = framed.into_parts();
         client = parts.io;
         parts.io = server;
         framed = Framed::from_parts(parts);
 
-        let res = framed.next().await.unwrap();
+        let _res = framed.next().await.unwrap();
 
         assert_eq!(framed.codec().next_handshake_status, ServerHandshakeStatus::WriteAutoSwitch);
 
@@ -577,10 +574,9 @@ mod test {
             0xe9, 0x43, 0x36, 0x24, 0x4c, 0x71, 0xef, 0x32, 0x1a, 0x5d,
         ];
 
-        framed.send(BytesMut::from(&auto_switch_response_data[..])).await;
+        let _ = framed.send(BytesMut::from(&auto_switch_response_data[..])).await;
 
         let mut parts = framed.into_parts();
-        client = parts.io;
         parts.io = server;
         framed = Framed::from_parts(parts);
 

--- a/pisa-proxy/protocol/mysql/src/util.rs
+++ b/pisa-proxy/protocol/mysql/src/util.rs
@@ -161,6 +161,7 @@ impl BufExt for BytesMut {}
 
 pub trait BufMutExt: BufMut {
     fn put_lenc_int(&mut self, n: u64, is_num: bool) {
+        // See https://dev.mysql.com/doc/internals/en/integer.html#length-encoded-integer
         if n == 0 {
             if is_num {
                 self.put_u8(0);


### PR DESCRIPTION
Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed:
Add encode for ok packet, Also this pr fixed:
1. Fix put_lenc_int put 0xfb when `n` is num.
2. Fix other error for unit test of server codec

ref: #257 