### PR TITLE
fix(pisa-proxy, parser): fix format TableIdent and InExprs

### DIFF
--- a/pisa-proxy/parser/mysql/src/ast/base.rs
+++ b/pisa-proxy/parser/mysql/src/ast/base.rs
@@ -224,7 +224,9 @@ impl Expr {
                 }
 
                 in_expr.push("IN".to_string());
-                in_expr.push(exprs_str.join(","));
+                in_expr.push("(".to_string());
+                in_expr.push(exprs_str.join(", "));
+                in_expr.push(")".to_string());
 
                 in_expr.join(" ")
             }
@@ -940,6 +942,7 @@ impl Value {
                 }
 
                 value.push_str(table);
+                value.push('.');
                 value.push_str(field);
 
                 value

--- a/pisa-proxy/parser/mysql/src/ast/mod.rs
+++ b/pisa-proxy/parser/mysql/src/ast/mod.rs
@@ -71,6 +71,27 @@ pub enum SqlStmt {
     None,
 }
 
+impl SqlStmt {
+    pub fn format(&self) -> String {
+        match self {
+            Self::SelectStmt(stmt) => {
+                stmt.format()
+            }
+
+            Self::InsertStmt(stmt) => {
+                stmt.format()
+            }
+
+            Self::UpdateStmt(stmt) => {
+                stmt.format()
+            }
+
+            // Implements the format method when developing sharding in the future
+            _x => todo!(),
+        }
+    }
+}
+
 impl Visitor for SqlStmt {
     fn visit<T>(&mut self, tf: &mut T) -> Self
     where


### PR DESCRIPTION
Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?


What's Changed:
1. Fix format TableIdent and InExprs.
2. Add format method to `SqlStmt` enum. 
