### PR TITLE
fix(pisa-proxy, parser): fix `PARTITION` format incorrect for `Insert` stmt

### DIFF
--- a/pisa-proxy/parser/mysql/src/ast/dml.rs
+++ b/pisa-proxy/parser/mysql/src/ast/dml.rs
@@ -2391,18 +2391,22 @@ impl InsertStmt {
         }
 
         insert.push(self.table_name.clone());
-        insert.push(
-            vec![
-                "PARTITION (".to_string(),
-                self.partition_names
-                    .iter()
-                    .map(|x| x.to_string())
-                    .collect::<Vec<String>>()
-                    .join(","),
-                ")".to_string(),
-            ]
-            .join(" "),
-        );
+
+        if !self.partition_names.is_empty() {
+            insert.push(
+                vec![
+                    "PARTITION (".to_string(),
+                    self.partition_names
+                        .iter()
+                        .map(|x| x.to_string())
+                        .collect::<Vec<String>>()
+                        .join(","),
+                    ")".to_string(),
+                ]
+                .join(" "),
+            );
+        }
+        
 
         if self.is_set {
             insert.push("SET".to_string())


### PR DESCRIPTION
Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed:
1. Fix `PARTATION` format incorrect for `Insert` stmt.
