### PR TITLE
Feat(pisa-proxy, parser): change method trans return type to &mut self for Transformer trait

### DIFF
--- a/pisa-proxy/parser/mysql/src/ast/api.rs
+++ b/pisa-proxy/parser/mysql/src/ast/api.rs
@@ -48,7 +48,7 @@ include!(concat!(env!("OUT_DIR"), "/ast_api.rs"));
 ///}
 ///```
 pub trait Transformer {
-    fn trans(&mut self, node: &mut Node) -> Self
+    fn trans(&mut self, node: &mut Node) -> &mut Self
     where
         Self: Sized;
 }

--- a/pisa-proxy/parser/mysql/src/ast/base.rs
+++ b/pisa-proxy/parser/mysql/src/ast/base.rs
@@ -1454,7 +1454,7 @@ mod test {
     #[test]
     fn test_value() {
         impl Transformer for S {
-            fn trans(&mut self, node: &mut Node) -> Self {
+            fn trans(&mut self, node: &mut Node) -> &mut Self {
                 match node {
                     Node::Value(Value::Text { span: _, value }) => {
                         if self.is_default {
@@ -1473,7 +1473,7 @@ mod test {
                     _ => {}
                 };
 
-                self.clone()
+                self
             }
         }
 

--- a/pisa-proxy/parser/mysql/src/ast/mod.rs
+++ b/pisa-proxy/parser/mysql/src/ast/mod.rs
@@ -149,7 +149,7 @@ mod test {
         }
 
         impl Transformer for S {
-            fn trans(&mut self, node: &mut Node) -> Self {
+            fn trans(&mut self, node: &mut Node) -> &mut Self {
                 match node {
                     Node::Value(Value::Text { span, value }) => {
                         *span = Span::new(1, 1);
@@ -165,7 +165,7 @@ mod test {
 
                 self.a = "11111".to_string();
 
-                self.clone()
+                self
             }
         }
 


### PR DESCRIPTION
Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?


What's Changed:
1. Changed method trans return type to `&mut self `for `Transformer` trait to reduce clone.
