### PR TITLE
chore(ci): add cache for kaniko

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,8 @@ jobs:
           build_file: pisa-controller/hack/Dockerfile 
           tag_with_latest: true
           extra_args: --build-arg GIT_BRANCH=${{ steps.vars.outputs.branch }} --build-arg GIT_COMMIT=${{ steps.vars.outputs.sha_short }} --build-arg GIT_TAG=${{ steps.vars.outputs.tags }}
+          cache: true
+          cache_registry: pisanixio/controller-cache
 
 
   pisa-proxy:
@@ -83,4 +85,6 @@ jobs:
           build_file: pisa-proxy/hack/Dockerfile
           tag_with_latest: true
           extra_args: --build-arg GIT_BRANCH=${{ steps.vars.outputs.branch }} --build-arg GIT_COMMIT=${{ steps.vars.outputs.sha_short }} --build-arg GIT_TAG=${{ steps.vars.outputs.tags }}
+          cache: true
+          cache_registry: pisanixio/proxy-cache
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,6 +54,8 @@ jobs:
           build_file: pisa-controller/hack/Dockerfile 
           tag_with_latest: true
           extra_args: --build-arg GIT_BRANCH=${{ steps.vars.outputs.branch }} --build-arg GIT_COMMIT=${{ steps.vars.outputs.sha_short }} --build-arg GIT_TAG=${{ steps.vars.outputs.tags }}
+          cache: true
+          cache_registry: pisanixio/controller-cache
       - name: "Pisa-Proxy kaniko build"
         uses: mlycore/action-kaniko@master
         with:
@@ -64,6 +66,8 @@ jobs:
           build_file: pisa-proxy/hack/Dockerfile
           tag_with_latest: true
           extra_args: --build-arg GIT_BRANCH=${{ steps.vars.outputs.branch }} --build-arg GIT_COMMIT=${{ steps.vars.outputs.sha_short }} --build-arg GIT_TAG=${{ steps.vars.outputs.tags }}
+          cache: true
+          cache_registry: pisanixio/proxy-cache
       - name: "install Pisa Controller"
         run: |
           set -x 


### PR DESCRIPTION
Signed-off-by: mlycore <maxwell92@126.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed:
- Enable cache for Kaniko build action in both build and integration
- Set Kaniko cache_registry to `pisanixio/controller-cache` and `pisanixio/proxy-cache` respectively