### PR TITLE
fix(pisa-proxy, parser): Fix parse failed which contains "a.*" in sql statement

### DIFF
--- a/pisa-proxy/parser/mysql/src/ast/ddl.rs
+++ b/pisa-proxy/parser/mysql/src/ast/ddl.rs
@@ -14,7 +14,7 @@
 
 use lrpar::Span;
 
-use crate::ast::{base::*, CreateUser, FieldType, SelectStmt};
+use crate::ast::{base::*, dml::TableIdent, CreateUser, FieldType, SelectStmt};
 
 #[derive(Debug, Clone)]
 pub enum Create {
@@ -91,7 +91,7 @@ pub struct ViewQueryBlock {
 pub struct ViewTail {
     pub span: Span,
     pub view_suid: ViewSuid,
-    pub view_name: String,
+    pub view_name: TableIdent,
     pub columns: Vec<Value>,
     pub view_query_block: ViewQueryBlock,
 }
@@ -141,7 +141,7 @@ pub struct TriggerTail {
     pub sp_name: String,
     pub trg_action_time: TrgActionTime,
     pub trg_event: TrgEvent,
-    pub table_name: String,
+    pub table_name: TableIdent,
     pub trigger_follows_precedes_clause: TriggerFollowsPrecedesClause,
     pub sp_proc_stmt: Option<String>,
 }
@@ -207,7 +207,7 @@ pub struct CreateCommonIndexStmt {
     pub opt_unique: bool,
     pub index_name: String,
     pub opt_index_type_clause: Option<IndexTypeClause>,
-    pub table_name: String,
+    pub table_name: TableIdent,
     pub key_list_with_expression: Vec<KeyPartWithExpression>,
     pub opt_index_options: Option<Vec<IndexOption>>,
     pub opt_index_lock_and_algorithm: Option<IndexLockAndAlgorithm>,
@@ -217,7 +217,7 @@ pub struct CreateCommonIndexStmt {
 pub struct CreateFullTextIndexStmt {
     pub span: Span,
     pub index_name: String,
-    pub table_name: String,
+    pub table_name: TableIdent,
     pub key_list_with_expression: Vec<KeyPartWithExpression>,
     pub opt_fulltext_index_options: Option<Vec<FullTextIndexOption>>,
     pub opt_index_lock_and_algorithm: Option<IndexLockAndAlgorithm>,
@@ -227,7 +227,7 @@ pub struct CreateFullTextIndexStmt {
 pub struct CreateSpatialIndexStmt {
     pub span: Span,
     pub index_name: String,
-    pub table_name: String,
+    pub table_name: TableIdent,
     pub key_list_with_expression: Vec<KeyPartWithExpression>,
     pub opt_spatial_index_options: Option<Vec<SpatialIndexOption>>,
     pub opt_index_lock_and_algorithm: Option<IndexLockAndAlgorithm>,

--- a/pisa-proxy/parser/mysql/src/ast/dml.rs
+++ b/pisa-proxy/parser/mysql/src/ast/dml.rs
@@ -341,15 +341,16 @@ impl UnionOpt {
 
 #[derive(Debug, Clone)]
 pub enum Items {
-    Wild,
+    Wild(ItemWild),
     Items(Vec<Item>),
     None,
 }
 
+
 impl Items {
     pub fn format(&self) -> String {
         match self {
-            Self::Wild => "*".to_string(),
+            Self::Wild(_) => "*".to_string(),
             Self::None => "".to_string(),
             Self::Items(val) => val.iter().map(|x| x.format()).collect::<Vec<String>>().join(","),
         }
@@ -376,6 +377,11 @@ impl Visitor for Items {
             x => x.clone(),
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct ItemWild {
+    pub span: Span
 }
 
 #[derive(Debug, Clone)]
@@ -418,7 +424,7 @@ impl Visitor for Item {
 #[derive(Debug, Clone)]
 pub struct TableWild {
     pub span: Span,
-    pub scheme: Option<String>,
+    pub schema: Option<String>,
     pub table: String,
 }
 
@@ -426,8 +432,8 @@ impl TableWild {
     pub fn format(&self) -> String {
         let mut wild = Vec::with_capacity(3);
 
-        if let Some(scheme) = &self.scheme {
-            wild.push(scheme.to_string())
+        if let Some(schema) = &self.schema {
+            wild.push(schema.to_string())
         }
 
         wild.push(self.table.to_string());

--- a/pisa-proxy/parser/mysql/src/ast/dml.rs
+++ b/pisa-proxy/parser/mysql/src/ast/dml.rs
@@ -22,7 +22,7 @@ pub enum SelectStmt {
     SubQuery(Box<SubQuery>),
     With(Box<WithQuery>),
     ValueConstructor(Vec<Vec<Expr>>),
-    ExplicitTable(String),
+    ExplicitTable(TableIdent),
     None,
 }
 
@@ -57,7 +57,7 @@ impl SelectStmt {
                 vec!["VALUES".to_string(), cons.join(",")].join(" ")
             }
 
-            Self::ExplicitTable(val) => vec!["TABLE".to_string(), val.clone()].join(" "),
+            Self::ExplicitTable(val) => vec!["TABLE".to_string(), val.format()].join(" "),
 
             Self::None => "".to_string(),
         }
@@ -436,7 +436,7 @@ impl TableWild {
             wild.push(schema.to_string())
         }
 
-        wild.push(self.table.to_string());
+        wild.push(self.table.clone());
         wild.push(".*".to_string());
 
         wild.join("")
@@ -879,7 +879,7 @@ impl Visitor for TableFactor {
 #[derive(Debug, Clone)]
 pub struct SingleTable {
     pub span: Span,
-    pub table_name: String,
+    pub table_name: TableIdent,
     pub partition_names: Vec<String>,
     pub alias_name: Option<String>,
     //field `index_hints` unused yet
@@ -890,7 +890,7 @@ pub struct SingleTable {
 impl SingleTable {
     pub fn format(&self) -> String {
         let mut single = vec![
-            self.table_name.clone(),
+            self.table_name.format(),
 
         ];
 
@@ -928,6 +928,35 @@ impl Visitor for SingleTable {
         self.clone()
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct TableIdent {
+    pub span: Span,
+    pub schema: Option<String>,
+    pub name: String
+}
+
+impl TableIdent {
+    pub fn format(&self) -> String {
+        let mut table = String::with_capacity(self.name.len());
+
+        if let Some(schema) = &self.schema {
+            table.push_str(schema);
+            table.push('.');
+        }
+
+        table.push_str(&self.name);
+
+        table
+    }
+}
+
+impl Visitor for TableIdent {
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
+        self.clone()
+    }
+}
+
 
 #[derive(Debug, Clone)]
 pub enum SingleTableParens {
@@ -2364,7 +2393,7 @@ pub struct InsertStmt {
     pub lock: InsertLockOpt,
     pub ignore: bool,
     pub into: bool,
-    pub table_name: String,
+    pub table_name: TableIdent,
     pub partition_names: Vec<String>,
     pub is_set: bool,
     pub from_construct: Option<InsertFromConstruct>,
@@ -2389,7 +2418,7 @@ impl InsertStmt {
             insert.push("INTO".to_string())
         }
 
-        insert.push(self.table_name.clone());
+        insert.push(self.table_name.format());
 
         if !self.partition_names.is_empty() {
             insert.push(
@@ -2896,7 +2925,7 @@ pub struct DeleteStmt {
     pub ignore: bool,
     pub low_priority: bool,
     pub is_using: bool,
-    pub table_name: Option<String>,
+    pub table_name: Option<TableIdent>,
     pub alias_name: Option<String>,
     pub partition_names: Vec<String>,
     pub where_clause: Option<WhereClause>,
@@ -2930,7 +2959,7 @@ impl DeleteStmt {
 
         if let Some(name) = &self.table_name {
             delete.push("FROM".to_string());
-            delete.push(name.clone());
+            delete.push(name.format());
             if let Some(name) = &self.alias_name {
                 delete.push((*name).to_string());
             }
@@ -3148,7 +3177,7 @@ pub struct ShowTableDb {
 #[derive(Debug, Clone)]
 pub struct ShowCreateTableStmt {
     pub span: Span,
-    pub table: String,
+    pub table: TableIdent,
 }
 
 #[derive(Debug, Clone)]
@@ -3184,7 +3213,7 @@ pub enum ShowVariableType {
 #[derive(Debug, Clone)]
 pub struct ShowCreateViewStmt {
     pub span: Span,
-    pub view_name: String,
+    pub view_name: TableIdent,
 }
 
 #[derive(Debug, Clone)]

--- a/pisa-proxy/parser/mysql/src/grammar.y
+++ b/pisa-proxy/parser/mysql/src/grammar.y
@@ -3590,8 +3590,6 @@ IDENT_sys -> (String, bool):
 table_wild -> TableWild:
     ident '.' '*'
     {
-   
-      println!("{:?}", "111");
       TableWild {
         span: $span,
         table: $1.0,

--- a/pisa-proxy/parser/mysql/src/grammar.y
+++ b/pisa-proxy/parser/mysql/src/grammar.y
@@ -674,7 +674,7 @@ select_items -> Items:
     }
   | '*'
     {
-      Items::Wild
+      Items::Wild( ItemWild { span: $span } )
     }
   ;
 
@@ -3590,17 +3590,19 @@ IDENT_sys -> (String, bool):
 table_wild -> TableWild:
     ident '.' '*'
     {
+   
+      println!("{:?}", "111");
       TableWild {
         span: $span,
         table: $1.0,
-        scheme: None
+        schema: None
       }
     }
   | ident '.' ident '.' '*'
     {
       TableWild {
         span: $span,
-        scheme: Some($1.0),
+        schema: Some($1.0),
         table: $3.0
       }
     }

--- a/pisa-proxy/parser/mysql/src/grammar.y
+++ b/pisa-proxy/parser/mysql/src/grammar.y
@@ -540,7 +540,7 @@ table_value_constructor -> Vec<Vec<Expr>>:
       }
   ;
 
-explicit_table -> String:
+explicit_table -> TableIdent:
     "TABLE" table_ident
     {
       $2
@@ -3520,18 +3520,22 @@ row_value_explicit -> Vec<Expr>:
     }
   ;
 
-table_ident -> String:
+table_ident -> TableIdent:
     ident
     {
-        $1.0
+    	TableIdent {
+	  span: $span,
+	  schema: None,
+	  name: $1.0,
+	}
     }
   | ident '.' ident
     {
-      let mut s = String::with_capacity($1.0.len()+1+$3.0.len());
-      s.push_str(&$1.0);
-      s.push('.');
-      s.push_str(&$3.0);
-      s
+    	TableIdent {
+          span: $span,
+          schema: Some($1.0),
+          name: $3.0,
+        }
     }
   ;
 

--- a/pisa-proxy/parser/mysql/src/lex.rs
+++ b/pisa-proxy/parser/mysql/src/lex.rs
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use lrlex::{lrlex_mod, DefaultLexeme, LRNonStreamingLexer};
+use lrlex::{DefaultLexeme, LRNonStreamingLexer};
 use lrpar::{LexError, Lexeme, Span};
 
 use super::charsets::CHARSETS;
 
-lrlex_mod!("token_map");
-
-use token_map::*;
+use super::lex_token::*;
 
 keyword_size!();
 
@@ -149,6 +147,10 @@ impl<'a> Scanner<'a> {
                 '*' => {
                     if !self.is_comment_executable {
                         lexemes.push(Ok(DefaultLexeme::new(T_ASTERISK, self.pos, 1)));
+                    }
+
+                    if self.is_ident_dot {
+                        self.is_ident_dot = false
                     }
                 }
 
@@ -666,6 +668,7 @@ impl<'a> Scanner<'a> {
             self.pos -= 1;
             // reset is_ident_dot is false
             self.is_ident_dot = false;
+
             return DefaultLexeme::new(T_IDENT, old_pos, length);
         }
 

--- a/pisa-proxy/parser/mysql/src/lib.rs
+++ b/pisa-proxy/parser/mysql/src/lib.rs
@@ -17,5 +17,13 @@ mod ident;
 mod charsets;
 pub mod lex;
 pub mod parser;
-
 pub mod ast;
+
+pub use lrpar::lex_api;
+pub use lrpar::Span;
+pub use lrlex;
+
+pub mod lex_token {
+    lrlex::lrlex_mod!("token_map");
+    pub use token_map::*;
+}


### PR DESCRIPTION
staement

Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed:

1.  Fix parse failed which contains "a.*" in sql statement.
2.  Fix some typo error.
3.  Add `Span` field to struct `Item::Wild` .
4. Add `TableIdent` struct for get `Span` info.