### PR TITLE
feat(pisa-proxy, parser): add LimitOption struct for get Span info

### DIFF
--- a/pisa-proxy/parser/mysql/src/ast/dml.rs
+++ b/pisa-proxy/parser/mysql/src/ast/dml.rs
@@ -1449,7 +1449,7 @@ impl Visitor for OrderClause {
 #[derive(Debug, Clone)]
 pub struct LimitClause {
     pub span: Span,
-    pub opts: Vec<String>,
+    pub opts: Vec<LimitOption>,
     pub offset: bool,
 }
 
@@ -1457,17 +1457,17 @@ impl LimitClause {
     pub fn format(&self) -> String {
         let mut clause = Vec::with_capacity(self.opts.len() + 1);
         clause.push("LIMIT".to_string());
-        clause.push(self.opts[0].to_string());
+        clause.push(self.opts[0].opt.clone());
 
         if self.offset {
             clause.push("OFFSET".to_string());
-            clause.push(self.opts[1].to_string());
+            clause.push(self.opts[1].opt.clone());
 
             return clause.join(" ");
         }
 
         if let Some(opt) = self.opts.get(1) {
-            clause.push(opt.to_string());
+            clause.push(opt.opt.clone());
             return clause.join(", ");
         }
 
@@ -1479,6 +1479,12 @@ impl Visitor for LimitClause {
     fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
         self.clone()
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct LimitOption {
+    pub span: Span,
+    pub opt: String,
 }
 
 #[derive(Debug, Clone)]
@@ -2829,7 +2835,7 @@ pub struct UpdateStmt {
     pub updates: Vec<UpdateElem>,
     pub where_clause: Option<WhereClause>,
     pub order_clause: Option<OrderClause>,
-    pub simple_limit: Option<String>,
+    pub simple_limit: Option<LimitOption>,
 }
 
 impl UpdateStmt {
@@ -2865,7 +2871,7 @@ impl UpdateStmt {
 
         if let Some(limit) = &self.simple_limit {
             update.push("LIMIT".to_string());
-            update.push((*limit).to_string())
+            update.push(limit.opt.clone())
         }
 
         update.join(" ")
@@ -2930,7 +2936,7 @@ pub struct DeleteStmt {
     pub partition_names: Vec<String>,
     pub where_clause: Option<WhereClause>,
     pub order_clause: Option<OrderClause>,
-    pub simple_limit: Option<String>,
+    pub simple_limit: Option<LimitOption>,
     pub table_alias_refs: Vec<String>,
     pub table_refs: Vec<TableRef>,
 }
@@ -2985,7 +2991,7 @@ impl DeleteStmt {
 
             if let Some(limit) = &self.simple_limit {
                 delete.push("LIMIT".to_string());
-                delete.push((*limit).to_string())
+                delete.push(limit.opt.clone())
             }
 
             return delete.join(" ");

--- a/pisa-proxy/parser/mysql/src/grammar.y
+++ b/pisa-proxy/parser/mysql/src/grammar.y
@@ -3247,6 +3247,7 @@ limit_clause -> LimitClause:
 limit_options -> LimitClause:
     limit_option
     {
+      
       LimitClause {
         span: $span,
         opts: vec![$1],
@@ -3271,30 +3272,46 @@ limit_options -> LimitClause:
     }
   ;
 
-limit_option -> String:
+limit_option -> LimitOption:
     ident
     {
-      $1.0
+      LimitOption {
+        span: $span,
+        opt: $1.0,
+      }
     }
   | param_marker
     {
-      $1
+      LimitOption {
+        span: $span,
+        opt: $1,
+      }
     }
   | 'ULONGLONG_NUM'
     {
-      String::from($lexer.span_str($1.as_ref().unwrap().span()))
+      LimitOption {
+        span: $span,
+        opt: String::from($lexer.span_str($1.as_ref().unwrap().span())),
+      }
+      
     }
   | 'LONG_NUM'
     {
-      String::from($lexer.span_str($1.as_ref().unwrap().span()))
+      LimitOption {
+        span: $span,
+        opt: String::from($lexer.span_str($1.as_ref().unwrap().span())),
+      }
     }
   | 'NUM'
     {
-      String::from($lexer.span_str($1.as_ref().unwrap().span()))
+      LimitOption {
+        span: $span,
+        opt: String::from($lexer.span_str($1.as_ref().unwrap().span())),
+      }
     }
   ;
 
-opt_simple_limit -> Option<String>:
+opt_simple_limit -> Option<LimitOption>:
     /* empty */        { None }
   | 'LIMIT' limit_option { Some($2)  }
   ;


### PR DESCRIPTION
Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?


What's Changed:
1. Add `LimitOption` struct for get `Span` info.
