### PR TITLE
feat(pisa-proxy, parser): Optimize Transformer trait, add `complete`

### DIFF
--- a/pisa-proxy/parser/mysql/src/ast/api.rs
+++ b/pisa-proxy/parser/mysql/src/ast/api.rs
@@ -27,7 +27,7 @@ include!(concat!(env!("OUT_DIR"), "/ast_api.rs"));
 /// }
 ///
 ///impl Transformer for S {
-///     fn trans(&mut self, node: &mut Node) -> Self {
+///     fn trans(&mut self, node: &mut Node) -> bool {
 ///         match node {
 ///            Node::Value(Value::Text { span, value }) => {
 ///                *span = Span::new(1, 1);
@@ -43,14 +43,16 @@ include!(concat!(env!("OUT_DIR"), "/ast_api.rs"));
 ///
 ///        self.a = "11111".to_string();
 ///
-///        self.clone()
+///        false
 ///    }
 ///}
 ///```
 pub trait Transformer {
-    fn trans(&mut self, node: &mut Node) -> &mut Self
-    where
-        Self: Sized;
+    // When return is true means that skip visit to other struct, otherwise continue visit.
+    fn trans(&mut self, node: &mut Node) -> bool;
+
+    //The `complete` means that visit the struct has completed, normally  its used to execute some `reset` logic.
+    fn complete(&mut self, node: &mut Node)  {}
 }
 
 ///Used to visit the structure, so that the visit ast tree can be traversed.

--- a/pisa-proxy/parser/mysql/src/ast/dml.rs
+++ b/pisa-proxy/parser/mysql/src/ast/dml.rs
@@ -72,20 +72,36 @@ impl Visitor for SelectStmt {
         match self {
             Self::Query(query) => {
                 let mut node = Node::Query(query);
-                tf.trans(&mut node);
+                let is_skip = tf.trans(&mut node);
 
-                let new_node = node.into_query().unwrap().visit(tf);
-                Self::Query(Box::new(new_node))
-            
+                let new_node = node.into_query().unwrap(); 
+                if is_skip {
+                    *self = Self::Query(Box::new(new_node.clone()));
+                    tf.complete(&mut Node::SelectStmt(self));
+                    return self.clone();
+                }
+
+                let new_node = new_node.visit(tf);
+                *self = Self::Query(Box::new(new_node));
+                tf.complete(&mut Node::SelectStmt(self));
+                self.clone()
             }
 
             Self::SubQuery(query) => {
                 let mut node = Node::SubQuery(query);
-                tf.trans(&mut node);
+                let is_skip = tf.trans(&mut node);
 
-                let new_node = node.into_sub_query().unwrap().visit(tf);
-                Self::SubQuery(Box::new(new_node))
-            
+                let new_node = node.into_sub_query().unwrap(); 
+                if is_skip {
+                    *self = Self::SubQuery(Box::new(new_node.clone()));
+                    tf.complete(&mut Node::SelectStmt(self));
+                    return self.clone();
+                }
+
+                let new_node = new_node.visit(tf);
+                *self = Self::SubQuery(Box::new(new_node));
+                tf.complete(&mut Node::SelectStmt(self));
+                self.clone()
             }
 
             Self::With(query) => {

--- a/pisa-proxy/parser/mysql/src/ast/mod.rs
+++ b/pisa-proxy/parser/mysql/src/ast/mod.rs
@@ -149,7 +149,7 @@ mod test {
         }
 
         impl Transformer for S {
-            fn trans(&mut self, node: &mut Node<'_>) -> &mut Self {
+            fn trans(&mut self, node: &mut Node<'_>) -> bool {
                 match node {
                     Node::Value(Value::Text { span, value }) => {
                         *span = Span::new(1, 1);
@@ -165,7 +165,7 @@ mod test {
 
                 self.a = "11111".to_string();
 
-                self
+                false
             }
         }
 


### PR DESCRIPTION

Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?


What's Changed:
1. Add `complete` function to `Transformer` trait.
When visit to struct has completed, `complete` function called.

2. Update the return value of `trans`.   
Change the return value from `&mut self` to `bool`  for `trans` function means that whether continue visit ast struct.
