### PR TITLE
Fix(pisa-proxy, parser): Fix generate AST struct incorrect which cont…

### DIFF
--- a/pisa-proxy/parser/mysql/src/lex.rs
+++ b/pisa-proxy/parser/mysql/src/lex.rs
@@ -649,13 +649,13 @@ impl<'a> Scanner<'a> {
 
                 '_' | '$' | '\\' | '\t' => false,
 
-                '.' => {
-                    // If is_ident_dot is true, continue scanning until there is an  exit condition.
-                    match scanner.is_ident_dot {
-                        true => false,
-                        false => true,
-                    }
-                }
+                //'.' => {
+                //    // If is_ident_dot is true, continue scanning until there is an  exit condition.
+                //    match scanner.is_ident_dot {
+                //        true => false,
+                //        false => true,
+                //    }
+                //}
 
                 _ => true,
             }
@@ -665,9 +665,9 @@ impl<'a> Scanner<'a> {
 
         // Check whether has the `ident.ident` format.
         if self.is_ident_dot {
-            self.pos -= 1;
             // reset is_ident_dot is false
-            self.is_ident_dot = false;
+            self.is_ident_dot = self.peek() == '.';
+            self.pos -= 1;
 
             return DefaultLexeme::new(T_IDENT, old_pos, length);
         }


### PR DESCRIPTION

Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed:
1. Fix  generate AST struct incorrect when parsing sql statement which contains like `a.b.c` .

When parsing `select a.b.select` from t, the result as follows:
before(incorrect AST):
```
                                     expr: SimpleIdentExpr(
                                              TableIdent {
                                                            span: Span {
                                                                start: 11,
                                                                end: 21,
                                                            },
                                                            field: "b.select",
                                                            table: "a",
                                                            schema: None,
                                                        },
                                                    ),

```

after(correct AST):
```
                                               expr: SimpleIdentExpr(
                                                        TableIdent {
                                                            span: Span {
                                                                start: 11,
                                                                end: 21,
                                                            },
                                                            field: "select",
                                                            table: "b",
                                                            schema: Some(
                                                                "a",
                                                            ),
                                                        },
                                                    ),

```