### PR TITLE
fix(proxy): update default value of admin host, port and loglevel to empty string

### DIFF
--- a/pisa-proxy/app/config/src/config.rs
+++ b/pisa-proxy/app/config/src/config.rs
@@ -154,6 +154,7 @@ impl PisaProxyConfigBuilder {
             )
             .arg(
                 Arg::new("loglevel")
+                    .short('l')
                     .long("log-level")
                     .help("Log level")
                     .default_value(DEFAULT_PISA_PROXY_ADMIN_LOG_LEVEL)

--- a/pisa-proxy/app/config/src/env_const.rs
+++ b/pisa-proxy/app/config/src/env_const.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 pub const DEFAULT_LOCAL_CONFIG: &str = "etc/config.toml";
-pub const DEFAULT_PISA_PROXY_ADMIN_LISTEN_HOST: &str = "0.0.0.0";
-pub const DEFAULT_PISA_PROXY_ADMIN_LISTEN_PORT: &str = "5591";
-pub const DEFAULT_PISA_PROXY_ADMIN_LOG_LEVEL: &str = "WARN";
+pub const DEFAULT_PISA_PROXY_ADMIN_LISTEN_HOST: &str = "";
+pub const DEFAULT_PISA_PROXY_ADMIN_LISTEN_PORT: &str = "";
+pub const DEFAULT_PISA_PROXY_ADMIN_LOG_LEVEL: &str = "";
 pub const DEFAULT_PISA_CONTROLLER_HOST: &str = "";
 pub const DEFAULT_PISA_CONTROLLER_NAMESPACE: &str = "pisa-system";
 pub const DEFAULT_PISA_CONTROLLER_SERVICE: &str = "pisa-controller";


### PR DESCRIPTION
<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed:
- using `l` for short flag of `loglevel`
- update default value of admin host, port and loglevel to empty string


