### PR TITLE
fix(proxy): checking config.proxy before build servers

### DIFF
--- a/pisa-proxy/app/config/src/config.rs
+++ b/pisa-proxy/app/config/src/config.rs
@@ -219,7 +219,7 @@ impl PisaProxyConfigBuilder {
                 "http://{}/apis/configs.database-mesh.io/v1alpha1/namespaces/{}/proxyconfigs/{}",
                 self._pisa_controller_host, self._deployed_ns, self._deployed_name
             );
-            builder.build_from_http(http_path).unwrap()
+            builder.build_from_http(http_path).unwrap_or_default()
         };
 
         if !self._log_level.is_empty() {

--- a/pisa-proxy/cmd/pisa/src/main.rs
+++ b/pisa-proxy/cmd/pisa/src/main.rs
@@ -69,18 +69,14 @@ fn main() {
             });
         }
         None => {
-            let mut servers = Vec::with_capacity(1);
             let http_server = PisaHttpServerFactory::new(config.clone(), MetricsManager::new())
                 .build_http_server(HttpServerKind::Rocket);
             build_runtime().block_on(async move {
-                servers.push(tokio::spawn(new_http_server(http_server)));
-
-                for server in servers {
-                    if let Err(e) = server.await {
+                if let Err(e) = tokio::spawn(new_http_server(http_server)).await {
                         error!("{:?}", e)
                     }
                 }
-            });
+            );
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Close #317  <!-- Associate issue that describes the problem the PR tries to solve. -->

What's Changed:
- Using `unwrap_or_default()` to handle invalid http request
- Checking config.proxy before build servers, if none, only start http server