### PR TITLE
feat(pisa-daemon, config): add `Endpoint` field to `Service`

### DIFF
--- a/pisa-daemon/app/config/src/config.rs
+++ b/pisa-daemon/app/config/src/config.rs
@@ -35,8 +35,15 @@ pub struct App {
 #[derive(Debug, Deserialize, Default)]
 pub struct Service {
     pub name: String,
+    pub endpoints: Vec<Endpoint>,
     pub qos_class: Option<QosClass>,
-    pub qos_group: Vec<QosGroup>,
+    pub qos_group: Option<QosGroup>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Endpoint {
+    pub ip: String,
+    pub port: u16,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -77,14 +84,18 @@ name = "testapp"
 [[app.service]]
 name = "test"
 qos_class = "guaranteed" # "burstable" | "besteffort"
+[[app.service.endpoints]]
+ip = "1.1.1.1"
+port = 3306
 
-[[app.service.qos_group]]
+[[app.service.endpoints]]
+ip = "1.1.1.1"
+port = 3307
+
+[app.service.qos_group]
 rate = "1MB"
 ceil = "1MB"
 
-[[app.service.qos_group]]
-rate = "1MB"
-ceil = "1MB"
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         println!("{:?}", config) ;

--- a/pisa-daemon/app/traffic_qos/src/tc.rs
+++ b/pisa-daemon/app/traffic_qos/src/tc.rs
@@ -125,7 +125,13 @@ name = "test1"
 [[app.service]]
 name = "svc"
 qos_class = "guaranteed" # "burstable" | "besteffort"
+[[app.service.endpoints]]
+ip = "1.1.1.1"
+port = 3306
 
+[[app.service.endpoints]]
+ip = "1.1.1.1"
+port = 3307
 [app.service.qos_group]
 rate = "1mbps"
 ceil = "1mbps"
@@ -136,6 +142,13 @@ name = "app1"
 [[app.service]]
 name = "test"
 qos_class = "guaranteed" # "burstable" | "besteffort"
+[[app.service.endpoints]]
+ip = "2.2.2.2"
+port = 3306
+
+[[app.service.endpoints]]
+ip = "2.2.2.2"
+port = 3307
 
 [app.service.qos_group]
 rate = "2mbps"
@@ -145,6 +158,7 @@ ceil = "2mbps"
     #[test]
     fn test_sort_app_service() {
         let mut config: Config = toml::from_str(config_str).unwrap();
+        println!("config {:?}", config);
         sort_app_serivce(&mut config);
         assert_eq!(config.app[0].name, "app1");
     }

--- a/pisa-daemon/tc/src/tc.rs
+++ b/pisa-daemon/tc/src/tc.rs
@@ -16,9 +16,9 @@ use std::process::Command;
 
 #[derive(Clone)]
 pub struct QdiscRootAttr<'a> {
-    netns: Option<&'a str>,
-    device: &'a str,
-    typ: &'a str,
+    pub netns: Option<&'a str>,
+    pub device: &'a str,
+    pub typ: &'a str,
 }
 
 pub fn add_root_qdisc<'a>(attr: &QdiscRootAttr<'a>) -> bool {
@@ -78,12 +78,12 @@ pub fn show_qdisc(device: String) -> bool {
 }
 
 pub struct ClassAttr<'a> {
-    netns: Option<&'a str>,
-    device: &'a str,
-    parent: Option<&'a str>,
-    class_id: &'a str,
-    rate: &'a str,
-    ceil: Option<&'a str>,
+    pub netns: Option<&'a str>,
+    pub device: &'a str,
+    pub parent: Option<&'a str>,
+    pub class_id: &'a str,
+    pub rate: &'a str,
+    pub ceil: Option<&'a str>,
 }
 
 pub fn add_class<'a>(attr: &ClassAttr<'a>) -> bool {


### PR DESCRIPTION
Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?


What's Changed:
1.  Add `Endpoint` field to `Service`.
2.  Changed `qos_group` type from Vec to Option.
3. Fix some unit test error.