### PR TITLE
fix(runtime): fix return incorrect results when execute `count` function

### DIFF
--- a/pisa-proxy/protocol/mysql/src/client/codec.rs
+++ b/pisa-proxy/protocol/mysql/src/client/codec.rs
@@ -17,6 +17,7 @@ use std::{
     ops::{Deref, DerefMut},
     pin::Pin,
     task::{Context, Poll},
+    default::Default,
 };
 
 use bytes::{Buf, BufMut, BytesMut};
@@ -281,19 +282,19 @@ impl<'a> Stream for ResultsetStream<'a> {
 }
 
 #[pin_project]
-pub struct QueryResultStream<'a, T: AsRef<[u8]>> {
+pub struct QueryResultStream<'a, T: AsRef<[u8]> + Default> {
     #[pin]
     rs: ResultsetStream<'a>,
     row_data: RowDataTyp<T>,
 }
 
-impl<'a, T: AsRef<[u8]>> QueryResultStream<'a, T> {
+impl<'a, T: AsRef<[u8]> + Default> QueryResultStream<'a, T> {
     pub fn new(rs: ResultsetStream<'a>, row_data: RowDataTyp<T>) -> Self {
         QueryResultStream { rs, row_data }
     }
 }
 
-impl<'a, T: AsRef<[u8]> + Clone + From<bytes::BytesMut>> Stream for QueryResultStream<'a, T> {
+impl<'a, T: AsRef<[u8]> + Default + Clone + From<bytes::BytesMut>> Stream for QueryResultStream<'a, T> {
     type Item = Result<RowDataTyp<T>, ProtocolError>;
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let me = self.project();

--- a/pisa-proxy/protocol/mysql/src/macros.rs
+++ b/pisa-proxy/protocol/mysql/src/macros.rs
@@ -15,7 +15,7 @@
 #[macro_export]
 macro_rules! gen_row_data {
     ($name:ident, $($var:ident($ty:ty)),*) => {
-        impl<T: AsRef<[u8]>> RowData<T> for RowDataTyp<T> {
+        impl<T: AsRef<[u8]> + Default> RowData<T> for RowDataTyp<T> {
             fn with_buf(&mut self, buf: T)  {
                 match self {
                     $($name::$var(x) => x.with_buf(buf),)*

--- a/pisa-proxy/protocol/mysql/src/row.rs
+++ b/pisa-proxy/protocol/mysql/src/row.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{sync::Arc, str::FromStr};
-
+use std::{sync::Arc, str::FromStr, default::Default};
+use bytes::Buf;
 use crate::{
     column::ColumnInfo,
     err::DecodeRowError,
@@ -29,7 +29,7 @@ pub trait RowData<T: AsRef<[u8]>> {
 }
 
 #[derive(Clone, Debug)]
-pub enum RowDataTyp<T: AsRef<[u8]>> {
+pub enum RowDataTyp<T: AsRef<[u8]> + Default> {
     Text(RowDataText<T>),
     Binary(RowDataBinary<T>),
 }
@@ -63,10 +63,19 @@ impl RowDataCommon {
 }
 
 // For ProtocolText::ResultsetRow
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct RowDataText<T: AsRef<[u8]>> {
     common: RowDataCommon,
     buf: T,
+}
+
+impl<T: AsRef<[u8]> + Default> Clone for RowDataText<T> {
+    fn clone(&self) -> Self {
+        RowDataText {
+            common: self.common.clone(),
+            buf: T::default(),
+        }
+    }
 }
 
 impl<T: AsRef<[u8]>> RowDataText<T> {
@@ -113,13 +122,25 @@ impl<T: AsRef<[u8]>> RowData<T> for RowDataText<T> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct RowDataBinary<T: AsRef<[u8]>> {
     common: RowDataCommon,
     null_map: Vec<u8>,
     buf: T,
     start_pos: usize,
 }
+
+impl<T: AsRef<[u8]> + Default> Clone for RowDataBinary<T> {
+    fn clone(&self) -> Self {
+        Self {
+            common: self.common.clone(),
+            null_map: self.null_map.clone(),
+            start_pos: self.start_pos,
+            buf: T::default(),
+        }
+    }
+}
+
 
 impl<T: BufExt + AsRef<[u8]>> RowDataBinary<T> {
     pub fn new(columns: Arc<[ColumnInfo]>, buf: T) -> RowDataBinary<T> {
@@ -142,8 +163,6 @@ impl<T: BufExt + AsRef<[u8]>> RowDataBinary<T> {
         RowDataBinary { common, null_map, buf, start_pos: 0, }
     }
 }
-
-use bytes::Buf;
 
 impl<T: AsRef<[u8]>> RowData<T> for RowDataBinary<T> {
     fn with_buf(&mut self, buf: T) {
@@ -256,9 +275,9 @@ impl<T: AsRef<[u8]>> RowData<T> for RowDataBinary<T> {
 
 
 // Box has default 'static bound, use `'e` lifetime relax bound.
-pub fn decode_with_name<'e, T: AsRef<[u8]>, V: Value + std::str::FromStr>(row_data: &mut RowDataTyp<T>, name: &str, is_binary: bool) -> Result<Option<V>,  Box<dyn std::error::Error + Send + Sync + 'e> > 
+pub fn decode_with_name<'e, T, V>(row_data: &mut RowDataTyp<T>, name: &str, is_binary: bool) -> Result<Option<V>,  Box<dyn std::error::Error + Send + Sync + 'e> > 
 where 
-    T: AsRef<[u8]>,
+    T: AsRef<[u8]> + Default,
     V: Value + std::str::FromStr,
     <V as FromStr>::Err: std::error::Error + Sync + Send + 'e
 {

--- a/pisa-proxy/runtime/mysql/src/transaction_fsm.rs
+++ b/pisa-proxy/runtime/mysql/src/transaction_fsm.rs
@@ -445,11 +445,11 @@ impl TransFsm {
         self.client_conn = Some(conn)
     }
 
-    pub fn get_shard_conn(&mut self) -> Vec<PoolConn<ClientConn>> {
+    pub fn get_shard_conns(&mut self) -> Vec<PoolConn<ClientConn>> {
         std::mem::replace(&mut self.shard_cache_conn, Vec::new())
     }
 
-    pub fn put_shard_conn(&mut self, conns: Vec<PoolConn<ClientConn>>) {
+    pub fn put_shard_conns(&mut self, conns: Vec<PoolConn<ClientConn>>) {
         self.shard_cache_conn = conns;
     }
 


### PR DESCRIPTION
This PR also has the following optimization:
1. Implements `Clone` trait manualy for `RowDataText`, `RowDataBinary` to reduce clone overhead.
2. Optimized `get_shard_conns` to avoid possible conns leak.

Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
What's Changed:
Fixed return incorrect results when execute `count` function.
This PR also has the following optimization:
1. Implements `Clone` trait manualy for `RowDataText`, `RowDataBinary` to reduce clone overhead.
2. Optimized `get_shard_conns` to avoid possible conns leak.
