### PR TITLE
optimize(parser): Optimize ast visitor, remove clone method

### DIFF
--- a/pisa-proxy/parser/mysql/src/ast/api.rs
+++ b/pisa-proxy/parser/mysql/src/ast/api.rs
@@ -58,11 +58,6 @@ pub trait Transformer {
 ///Used to visit the structure, so that the visit ast tree can be traversed.
 ///Every struct should implement `Visitor` trait.
 pub trait Visitor {
-    fn visit<V>(&mut self, _tf: &mut V) -> Self
-    where
-        Self: Sized + Clone,
-        V: Transformer,
-    {
-        self.clone()
-    }
+    fn visit<V>(&mut self, _tf: &mut V) 
+        where Self: Sized + Clone, V: Transformer { }
 }

--- a/pisa-proxy/parser/mysql/src/ast/base.rs
+++ b/pisa-proxy/parser/mysql/src/ast/base.rs
@@ -464,105 +464,72 @@ impl Expr {
 }
 
 impl Visitor for Expr {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         match self {
-            Self::BinaryOperationExpr { span, operator, left, right } => {
+            Self::BinaryOperationExpr { left, right, .. } => {
                 let mut new_left = Node::Expr(left);
                 tf.trans(&mut new_left);
 
                 let mut new_right = Node::Expr(right);
                 tf.trans(&mut new_right);
 
-                Self::BinaryOperationExpr {
-                    span: *span,
-                    operator: *operator,
-                    left: Box::new(new_left.into_expr().unwrap().visit(tf)),
-                    right: Box::new(new_right.into_expr().unwrap().visit(tf)),
-                }
+                new_left.into_expr().unwrap().visit(tf);
+                new_right.into_expr().unwrap().visit(tf);
             }
 
-            Self::UnaryOperationExpr { span, expr, operator } => {
+            Self::UnaryOperationExpr {expr, .. } => {
                 let mut new_expr = Node::Expr(expr);
                 tf.trans(&mut new_expr);
 
-                Self::UnaryOperationExpr {
-                    span: *span,
-                    operator: *operator,
-                    expr: Box::new(new_expr.into_expr().unwrap().visit(tf)),
-                }
+                new_expr.into_expr().unwrap().visit(tf);
             }
 
-            Self::IsTruthExpr { span, expr, is_not, is_true } => {
-                let mut new_expr = Node::Expr(expr);
-                tf.trans(&mut new_expr);
-                let new_expr = new_expr.into_expr().unwrap();
-
-                Self::IsTruthExpr {
-                    span: *span,
-                    expr: Box::new(new_expr.visit(tf)),
-                    is_not: *is_not,
-                    is_true: *is_true,
-                }
-            }
-
-            Self::IsUnknownExpr { span, expr, is_not } => {
-                let mut new_expr = Node::Expr(expr);
-                tf.trans(&mut new_expr);
-                let new_expr = new_expr.into_expr().unwrap();
-
-                Self::IsUnknownExpr {
-                    span: *span,
-                    expr: Box::new(new_expr.visit(tf)),
-                    is_not: *is_not,
-                }
-            }
-
-            Self::IsNullExpr { span, expr, is_not } => {
-                let mut new_expr = Node::Expr(expr);
-                tf.trans(&mut new_expr);
-                let new_expr = new_expr.into_expr().unwrap();
-
-                Self::IsNullExpr {
-                    span: *span,
-                    expr: Box::new(new_expr.visit(tf)),
-                    is_not: *is_not,
-                }
-            }
-
-            Self::InExpr { span, expr, is_not, exprs } => {
+            Self::IsTruthExpr { expr, .. } => {
                 let mut new_expr = Node::Expr(expr);
                 tf.trans(&mut new_expr);
 
-                let mut new_exprs = Vec::with_capacity(exprs.len());
+                new_expr.into_expr().unwrap().visit(tf);
+            }
+
+            Self::IsUnknownExpr { expr, ..} => {
+                let mut new_expr = Node::Expr(expr);
+                tf.trans(&mut new_expr);
+
+                new_expr.into_expr().unwrap().visit(tf);
+            }
+
+            Self::IsNullExpr { expr, .. } => {
+                let mut new_expr = Node::Expr(expr);
+                tf.trans(&mut new_expr);
+
+                new_expr.into_expr().unwrap().visit(tf);
+
+            }
+
+            Self::InExpr { expr, exprs, .. } => {
+                let mut new_expr = Node::Expr(expr);
+                tf.trans(&mut new_expr);
+
                 for v in exprs {
                     let mut node = Node::Expr(v);
                     tf.trans(&mut node);
 
-                    new_exprs.push(node.into_expr().unwrap().visit(tf));
-                }
-
-                Self::InExpr {
-                    span: *span,
-                    expr: Box::new(new_expr.into_expr().unwrap().visit(tf)),
-                    is_not: *is_not,
-                    exprs: new_exprs,
+                    node.into_expr().unwrap().visit(tf);
                 }
             }
 
-            Self::MemberOfExpr { span, expr, of_expr } => {
+            Self::MemberOfExpr { expr, of_expr, .. } => {
                 let mut new_expr = Node::Expr(expr);
                 tf.trans(&mut new_expr);
 
                 let mut new_of_expr = Node::Expr(of_expr);
                 tf.trans(&mut new_of_expr);
 
-                Self::MemberOfExpr {
-                    span: *span,
-                    expr: Box::new(new_expr.into_expr().unwrap().visit(tf)),
-                    of_expr: Box::new(new_of_expr.into_expr().unwrap().visit(tf)),
-                }
+                new_expr.into_expr().unwrap().visit(tf);
+                new_of_expr.into_expr().unwrap().visit(tf);
             }
-            Self::BetweenExpr { span, is_not, expr, left, right } => {
+
+            Self::BetweenExpr { expr, left, right, .. } => {
                 let mut new_expr = Node::Expr(expr);
                 tf.trans(&mut new_expr);
 
@@ -572,30 +539,23 @@ impl Visitor for Expr {
                 let mut new_right_expr = Node::Expr(right);
                 tf.trans(&mut new_right_expr);
 
-                Self::BetweenExpr {
-                    span: *span,
-                    is_not: *is_not,
-                    expr: Box::new(new_expr.into_expr().unwrap().visit(tf)),
-                    left: Box::new(new_left_expr.into_expr().unwrap().visit(tf)),
-                    right: Box::new(new_right_expr.into_expr().unwrap().visit(tf)),
-                }
+                new_expr.into_expr().unwrap().visit(tf);
+                new_left_expr.into_expr().unwrap().visit(tf);
+                new_right_expr.into_expr().unwrap().visit(tf);
             }
 
-            Self::SoundsExpr { span, left, right } => {
+            Self::SoundsExpr { left, right, .. } => {
                 let mut new_left_expr = Node::Expr(left);
                 tf.trans(&mut new_left_expr);
 
                 let mut new_right_expr = Node::Expr(right);
                 tf.trans(&mut new_right_expr);
 
-                Self::SoundsExpr {
-                    span: *span,
-                    left: Box::new(new_left_expr.into_expr().unwrap().visit(tf)),
-                    right: Box::new(new_right_expr.into_expr().unwrap().visit(tf)),
-                }
+                new_left_expr.into_expr().unwrap().visit(tf);
+                new_right_expr.into_expr().unwrap().visit(tf);
             }
 
-            Self::LikeExpr { span, expr, is_not, pattern_expr, escape_expr } => {
+            Self::LikeExpr { expr, pattern_expr, escape_expr, .. } => {
                 let mut new_expr = Node::Expr(expr);
                 tf.trans(&mut new_expr);
 
@@ -605,204 +565,165 @@ impl Visitor for Expr {
                 if let Some(e) = escape_expr {
                     let mut new_escape_expr = Node::Expr(e);
                     tf.trans(&mut new_escape_expr);
-                    *escape_expr = Some(Box::new(new_escape_expr.into_expr().unwrap().visit(tf)))
+                    new_escape_expr.into_expr().unwrap().visit(tf);
                 }
 
-                Self::LikeExpr {
-                    span: *span,
-                    expr: Box::new(new_expr.into_expr().unwrap().visit(tf)),
-                    is_not: *is_not,
-                    pattern_expr: pattern_expr.clone(),
-                    escape_expr: escape_expr.clone(),
-                }
+                new_expr.into_expr().unwrap().visit(tf);
             }
 
-            Self::RegexpExpr { span, left, right, is_not } => {
+            Self::RegexpExpr { left, right, .. } => {
                 let mut new_left_expr = Node::Expr(left);
                 tf.trans(&mut new_left_expr);
 
                 let mut new_right_expr = Node::Expr(right);
                 tf.trans(&mut new_right_expr);
 
-                Self::RegexpExpr {
-                    span: *span,
-                    is_not: *is_not,
-                    left: Box::new(new_left_expr.into_expr().unwrap().visit(tf)),
-                    right: Box::new(new_right_expr.into_expr().unwrap().visit(tf)),
-                }
+                new_left_expr.into_expr().unwrap().visit(tf);
+                new_right_expr.into_expr().unwrap().visit(tf);
             }
 
-            Self::FuncCallExpr { span, name, args } => {
-                let mut new_exprs = Vec::with_capacity(args.len());
+            Self::FuncCallExpr { args, .. } => {
                 for v in args {
                     let mut node = Node::Expr(v);
                     tf.trans(&mut node);
 
-                    new_exprs.push(node.into_expr().unwrap().visit(tf));
+                    node.into_expr().unwrap().visit(tf);
                 }
-
-                Self::FuncCallExpr { span: *span, name: name.clone(), args: new_exprs }
             }
 
-            Self::VarExpr(val) => Self::VarExpr(val.clone()),
+            Self::VarExpr(_val) => {},
 
             Self::ValuesExpr(val) => {
                 let mut node = Node::Value(val);
                 tf.trans(&mut node);
 
-                Self::ValuesExpr(node.into_value().unwrap().visit(tf))
+                node.into_value().unwrap().visit(tf);
             }
 
-            Self::CastExpr { span, expr, cast_type } => {
+            Self::CastExpr { expr, .. } => {
                 let mut new_expr = Node::Expr(expr);
                 tf.trans(&mut new_expr);
 
-                Self::CastExpr {
-                    span: *span,
-                    expr: Box::new(new_expr.into_expr().unwrap().visit(tf)),
-                    cast_type: cast_type.clone(),
-                }
+                new_expr.into_expr().unwrap().visit(tf);
             }
 
             Self::SimpleIdentExpr(val) => {
                 let mut node = Node::Value(val);
                 tf.trans(&mut node);
 
-                Self::SimpleIdentExpr(node.into_value().unwrap().visit(tf))
+                node.into_value().unwrap().visit(tf);
             }
 
-            Self::CaseExpr { span, expr, when_exprs, else_expr } => {
+            Self::CaseExpr { expr, when_exprs, else_expr, .. } => {
                 if let Some(mut e) = expr.take() {
                     let mut new_expr = Node::Expr(&mut e);
                     tf.trans(&mut new_expr);
-                    *expr = Box::new(Some(new_expr.into_expr().unwrap().visit(tf)))
+                    new_expr.into_expr().unwrap().visit(tf);
                 }
 
-                let mut new_when_exprs = Vec::with_capacity(when_exprs.len());
                 for v in when_exprs {
                     let mut node = Node::WhenExpr(v);
                     tf.trans(&mut node);
 
-                    new_when_exprs.push(node.into_when_expr().unwrap().visit(tf));
+                    node.into_when_expr().unwrap().visit(tf);
                 }
 
                 if let Some(mut e) = else_expr.take() {
                     let mut new_expr = Node::Expr(&mut e);
                     tf.trans(&mut new_expr);
-                    *else_expr = Box::new(Some(new_expr.into_expr().unwrap().visit(tf)))
-                }
 
-                Self::CaseExpr {
-                    span: *span,
-                    expr: expr.clone(),
-                    when_exprs: new_when_exprs,
-                    else_expr: else_expr.clone(),
+                    new_expr.into_expr().unwrap().visit(tf);
                 }
             }
 
-            Self::CollateExpr { span, name, expr } => {
+            Self::CollateExpr { expr, .. } => {
                 let mut new_expr = Node::Expr(expr);
                 tf.trans(&mut new_expr);
 
-                Self::CollateExpr {
-                    span: *span,
-                    name: name.to_string(),
-                    expr: Box::new(new_expr.into_expr().unwrap().visit(tf)),
-                }
+                new_expr.into_expr().unwrap().visit(tf);
             }
 
             Self::CompSubQueryExpr(val) => {
                 let mut node = Node::CompSubQueryExpr(val);
                 tf.trans(&mut node);
 
-                Self::CompSubQueryExpr(Box::new(node.into_comp_sub_query_expr().unwrap().visit(tf)))
+                node.into_comp_sub_query_expr().unwrap().visit(tf);
             }
 
             Self::ExistsSubQuery(val) => {
                 let mut node = Node::SelectStmt(val);
                 tf.trans(&mut node);
 
-                Self::ExistsSubQuery(Box::new(node.into_select_stmt().unwrap().visit(tf)))
+                node.into_select_stmt().unwrap().visit(tf);
             }
 
-            Self::InSumExpr { span, expr, opt } => {
+            Self::InSumExpr { expr, .. } => {
                 let mut new_expr = Node::Expr(expr);
                 tf.trans(&mut new_expr);
 
-                Self::InSumExpr {
-                    span: *span,
-                    expr: Box::new(new_expr.into_expr().unwrap().visit(tf)),
-                    opt: *opt,
-                }
+                new_expr.into_expr().unwrap().visit(tf);
             }
 
-            Self::MatchAgainstExpr { span, idents, expr, fulltext_opts } => {
+            Self::MatchAgainstExpr { expr, .. } => {
                 let mut new_expr = Node::Expr(expr);
                 tf.trans(&mut new_expr);
 
-                Self::MatchAgainstExpr {
-                    span: *span,
-                    idents: idents.clone(),
-                    expr: Box::new(new_expr.into_expr().unwrap().visit(tf)),
-                    fulltext_opts: fulltext_opts.clone(),
-                }
+                new_expr.into_expr().unwrap().visit(tf);
             }
 
             Self::RowExpr(val) => {
-                let mut new_exprs = Vec::with_capacity(val.len());
                 for v in val {
                     let mut node = Node::Expr(v);
                     tf.trans(&mut node);
 
-                    new_exprs.push(node.into_expr().unwrap().visit(tf));
-                }
+                    node.into_expr().unwrap().visit(tf);
 
-                Self::RowExpr(new_exprs)
+                }
             }
 
             Self::LiteralExpr(val) => {
                 let mut node = Node::Value(val);
                 tf.trans(&mut node);
 
-                Self::LiteralExpr(node.into_value().unwrap().visit(tf))
+                node.into_value().unwrap().visit(tf);
             }
 
             Self::BinaryExpr(val) => {
                 let mut new_expr = Node::Expr(val);
                 tf.trans(&mut new_expr);
 
-                Self::BinaryExpr(Box::new(new_expr.into_expr().unwrap().visit(tf)))
+                new_expr.into_expr().unwrap().visit(tf);
             }
 
             Self::SubQueryExpr(val) => {
                 let mut new_expr = Node::SelectStmt(val);
                 tf.trans(&mut new_expr);
 
-                Self::SubQueryExpr(Box::new(new_expr.into_select_stmt().unwrap().visit(tf)))
+                new_expr.into_select_stmt().unwrap().visit(tf);
             }
 
             Self::SetFuncSpecExpr(val) => {
                 let mut node = Node::Expr(val);
                 tf.trans(&mut node);
 
-                Self::SetFuncSpecExpr(Box::new(node.into_expr().unwrap().visit(tf)))
+                node.into_expr().unwrap().visit(tf);
             }
 
-            Self::TimeIntervalUnit(val) => Self::TimeIntervalUnit(val.clone()),
+            Self::TimeIntervalUnit(_val) => {},
 
-            Self::DefaultExpr => Self::DefaultExpr,
+            Self::DefaultExpr => {},
 
-            Self::ParamMarkerExpr => Self::ParamMarkerExpr,
+            Self::ParamMarkerExpr => {},
 
-            Self::None => Self::None,
+            Self::None => {},
 
-            Self::Ori(val) => Self::Ori(val.clone()),
+            Self::Ori(_val) => {},
 
             Self::AggExpr(val) => {
                 let mut node = Node::AggExpr(val);
                 tf.trans(&mut node);
 
-                Self::AggExpr(node.into_agg_expr().unwrap().visit(tf))
+                node.into_agg_expr().unwrap().visit(tf);
             }
         }
     }
@@ -824,16 +745,16 @@ impl WhenExpr {
 }
 
 impl Visitor for WhenExpr {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut new_when_expr = Node::Expr(&mut self.when);
         tf.trans(&mut new_when_expr);
-        self.when = Box::new(new_when_expr.into_expr().unwrap().visit(tf));
+        //self.when = Box::new(new_when_expr.into_expr().unwrap().visit(tf));
+        new_when_expr.into_expr().unwrap().visit(tf);
 
         let mut new_then_expr = Node::Expr(&mut self.then);
         tf.trans(&mut new_then_expr);
-        self.then = Box::new(new_then_expr.into_expr().unwrap().visit(tf));
-
-        self.clone()
+        //self.then = Box::new(new_then_expr.into_expr().unwrap().visit(tf));
+        new_then_expr.into_expr().unwrap().visit(tf);
     }
 }
 
@@ -859,16 +780,18 @@ impl CompSubQueryExpr {
 }
 
 impl Visitor for CompSubQueryExpr {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut new_expr = Node::Expr(&mut self.expr);
         tf.trans(&mut new_expr);
-        self.expr = Box::new(new_expr.into_expr().unwrap().visit(tf));
+        //self.expr = Box::new(new_expr.into_expr().unwrap().visit(tf));
+        new_expr.into_expr().unwrap().visit(tf);
 
         let mut new_subqury = Node::SelectStmt(&mut self.subquery);
         tf.trans(&mut new_subqury);
-        self.subquery = new_subqury.into_select_stmt().unwrap().visit(tf);
+        //self.subquery = new_subqury.into_select_stmt().unwrap().visit(tf);
+        new_subqury.into_select_stmt().unwrap().visit(tf);
 
-        self.clone()
+        //self.clone()
     }
 }
 
@@ -921,9 +844,7 @@ impl CharsetOrBinary {
 }
 
 impl Visitor for CharsetOrBinary {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) { }
 }
 
 #[derive(Debug, Clone)]
@@ -1052,23 +973,29 @@ impl Value {
 }
 
 impl Visitor for Value {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         match self {
-            Self::Default { span, value } => {
+            Self::Default {  value, .. } => {
                 let mut new_value = Node::Value(value);
                 tf.trans(&mut new_value);
 
-                Self::Default {
-                    span: *span,
-                    value: Box::new(new_value.into_value().unwrap().visit(tf)),
-                }
+                new_value.into_value().unwrap().visit(tf);
+                //Self::Default {
+                //    span: *span,
+                //    value: Box::new(new_value.into_value().unwrap().visit(tf)),
+                //}
             }
 
             x => {
                 let mut new_value = Node::Value(x);
                 tf.trans(&mut new_value);
 
-                new_value.into_value().unwrap().clone()
+                //new_value.into_value().unwrap().visit(tf);
+                
+                //*x = new_value.into_value().unwrap();
+                //println!("sssssssssss111111  {:?}", new_value.into_value().unwrap());
+
+
             }
         }
     }
@@ -1082,30 +1009,33 @@ pub enum SetOptValues {
 }
 
 impl Visitor for SetOptValues {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         match self {
             Self::OptValues(value) => {
                 let mut node = Node::OptValues(value);
                 tf.trans(&mut node);
 
-                let new_value = node.into_opt_values().unwrap().visit(tf);
-                Self::OptValues(new_value)
+                //let new_value = node.into_opt_values().unwrap().visit(tf);
+                node.into_opt_values().unwrap().visit(tf);
+                //Self::OptValues(new_value)
             }
 
             Self::Transaction(value) => {
                 let mut node = Node::Transaction(value);
                 tf.trans(&mut node);
 
-                let new_value = node.into_transaction().unwrap().visit(tf);
-                Self::Transaction(new_value)
+                //let new_value = node.into_transaction().unwrap().visit(tf);
+                node.into_transaction().unwrap().visit(tf);
+                //Self::Transaction(new_value)
             }
 
             Self::OptTypeFollowing(value) => {
                 let mut node = Node::OptTypeFollowing(value);
                 tf.trans(&mut node);
 
-                let new_value = node.into_opt_type_following().unwrap().visit(tf);
-                Self::OptTypeFollowing(new_value)
+                //let new_value = node.into_opt_type_following().unwrap().visit(tf);
+                node.into_opt_type_following().unwrap().visit(tf);
+                //Self::OptTypeFollowing(new_value)
             }
         }
     }
@@ -1118,20 +1048,21 @@ pub struct OptValues {
 }
 
 impl Visitor for OptValues {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut opt_node = Node::SetOpts(&mut self.opt);
         tf.trans(&mut opt_node);
-        let new_opt = opt_node.into_set_opts().unwrap().visit(tf);
+        opt_node.into_set_opts().unwrap().visit(tf);
 
-        let mut new_values = Vec::with_capacity(self.values.len());
-        for v in &mut self.values {
+        //let mut new_values = Vec::with_capacity(self.values.len());
+        for v in self.values.iter_mut() {
             let mut node = Node::OptValue(v);
             tf.trans(&mut node);
-            let new_value = node.into_opt_value().unwrap().visit(tf);
-            new_values.push(new_value)
+            //let new_value = node.into_opt_value().unwrap().visit(tf);
+            node.into_opt_value().unwrap().visit(tf);
+            //new_values.push(new_value)
         }
 
-        OptValues { opt: new_opt, values: new_values }
+        //OptValues { opt: new_opt, values: new_values }
     }
 }
 
@@ -1145,42 +1076,47 @@ pub enum SetOpts {
 }
 
 impl Visitor for SetOpts {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         match self {
             Self::SetVariable(value) => {
                 let mut node = Node::SetVariable(value);
                 tf.trans(&mut node);
 
-                let new_value = node.into_set_variable().unwrap().visit(tf);
-                Self::SetVariable(new_value)
+                //let new_value = node.into_set_variable().unwrap().visit(tf);
+                node.into_set_variable().unwrap().visit(tf);
+                //Self::SetVariable(new_value)
             }
             Self::SetUserVar(value) => {
                 let mut node = Node::SetUserVar(value);
                 tf.trans(&mut node);
 
-                let new_value = node.into_set_user_var().unwrap().visit(tf);
-                Self::SetUserVar(new_value)
+                //let new_value = node.into_set_user_var().unwrap().visit(tf);
+                node.into_set_user_var().unwrap().visit(tf);
+                //Self::SetUserVar(new_value)
             }
             Self::SetSystemVar(value) => {
                 let mut node = Node::SetSystemVar(value);
                 tf.trans(&mut node);
 
-                let new_value = node.into_set_system_var().unwrap().visit(tf);
-                Self::SetSystemVar(new_value)
+                //let new_value = node.into_set_system_var().unwrap().visit(tf);
+                node.into_set_system_var().unwrap().visit(tf);
+                //Self::SetSystemVar(new_value)
             }
             Self::SetCharset(value) => {
                 let mut node = Node::SetCharset(value);
                 tf.trans(&mut node);
 
-                let new_value = node.into_set_charset().unwrap().visit(tf);
-                Self::SetCharset(new_value)
+                //let new_value = node.into_set_charset().unwrap().visit(tf);
+                node.into_set_charset().unwrap().visit(tf);
+                //Self::SetCharset(new_value)
             }
             Self::SetNames(value) => {
                 let mut node = Node::SetNames(value);
                 tf.trans(&mut node);
 
-                let new_value = node.into_set_names().unwrap().visit(tf);
-                Self::SetNames(new_value)
+                //let new_value = node.into_set_names().unwrap().visit(tf);
+                node.into_set_names().unwrap().visit(tf);
+                //Self::SetNames(new_value)
             }
         }
     }
@@ -1193,12 +1129,13 @@ pub struct SetVariable {
 }
 
 impl Visitor for SetVariable {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node = Node::ExprOrDefault(&mut self.value);
         tf.trans(&mut node);
 
-        let new_value = node.into_expr_or_default().unwrap().visit(tf);
-        SetVariable { var: self.var.clone(), value: new_value }
+        //let new_value = node.into_expr_or_default().unwrap().visit(tf);
+        node.into_expr_or_default().unwrap().visit(tf);
+        //SetVariable { var: self.var.clone(), value: new_value }
     }
 }
 
@@ -1214,17 +1151,18 @@ pub enum ExprOrDefault {
 }
 
 impl Visitor for ExprOrDefault {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         match self {
             Self::Expr(value) => {
                 let mut node = Node::Expr(value);
                 tf.trans(&mut node);
 
-                let new_value = node.into_expr().unwrap().visit(tf);
-                Self::Expr(new_value)
+                //let new_value = node.into_expr().unwrap().visit(tf);
+                node.into_expr().unwrap().visit(tf);
+                //Self::Expr(new_value)
             }
 
-            x => x.clone(),
+            _ => {},
         }
     }
 }
@@ -1236,13 +1174,14 @@ pub struct SetUserVar {
 }
 
 impl Visitor for SetUserVar {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node = Node::Expr(&mut self.expr);
         tf.trans(&mut node);
 
-        let new_value = node.into_expr().unwrap().visit(tf);
+        //let new_value = node.into_expr().unwrap().visit(tf);
+        node.into_expr().unwrap().visit(tf);
 
-        SetUserVar { var: self.var.clone(), expr: new_value }
+        //SetUserVar { var: self.var.clone(), expr: new_value }
     }
 }
 
@@ -1254,16 +1193,18 @@ pub struct SetSystemVar {
 }
 
 impl Visitor for SetSystemVar {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut opt_node = Node::SetVarIdentType(&mut self.opt_var);
         tf.trans(&mut opt_node);
-        let new_opt = opt_node.into_set_var_ident_type().unwrap().visit(tf);
+        //let new_opt = opt_node.into_set_var_ident_type().unwrap().visit(tf);
+        opt_node.into_set_var_ident_type().unwrap().visit(tf);
 
         let mut value_node = Node::ExprOrDefault(&mut self.value);
         tf.trans(&mut value_node);
-        let new_value = value_node.into_expr_or_default().unwrap().visit(tf);
+        //let new_value = value_node.into_expr_or_default().unwrap().visit(tf);
+        value_node.into_expr_or_default().unwrap().visit(tf);
 
-        Self { opt_var: new_opt, var: self.var.clone(), value: new_value }
+        //Self { opt_var: new_opt, var: self.var.clone(), value: new_value }
     }
 }
 
@@ -1274,13 +1215,14 @@ pub struct SetCharset {
 }
 
 impl Visitor for SetCharset {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node = Node::NewCharset(&mut self.new_value);
         tf.trans(&mut node);
 
-        let new_value = node.into_new_charset().unwrap().visit(tf);
+        //let new_value = node.into_new_charset().unwrap().visit(tf);
+        node.into_new_charset().unwrap().visit(tf);
 
-        Self { charset: self.charset.clone(), new_value }
+        //Self { charset: self.charset.clone(), new_value }
     }
 }
 
@@ -1291,9 +1233,7 @@ pub struct SetNames {
 }
 
 impl Visitor for SetNames {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) { }
 }
 
 #[derive(Debug, Clone)]
@@ -1307,9 +1247,7 @@ pub enum SetVarIdentType {
 }
 
 impl Visitor for SetVarIdentType {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) { }
 }
 
 #[derive(Debug, Clone)]
@@ -1320,9 +1258,7 @@ pub enum NewCharset {
 }
 
 impl Visitor for NewCharset {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) { }
 }
 
 #[derive(Debug, Clone)]
@@ -1335,9 +1271,7 @@ pub enum OptType {
 }
 
 impl Visitor for OptType {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) { }
 }
 
 #[derive(Debug, Clone)]
@@ -1347,21 +1281,23 @@ pub enum OptValue {
 }
 
 impl Visitor for OptValue {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         match self {
             Self::OptValueType(value) => {
                 let mut node = Node::OptValueType(value);
                 tf.trans(&mut node);
 
-                let new_value = node.into_opt_value_type().unwrap().visit(tf);
-                Self::OptValueType(new_value)
+                //let new_value = node.into_opt_value_type().unwrap().visit(tf);
+                node.into_opt_value_type().unwrap().visit(tf);
+                //Self::OptValueType(new_value)
             }
             Self::SetOpts(value) => {
                 let mut node = Node::SetOpts(value);
                 tf.trans(&mut node);
 
-                let new_value = node.into_set_opts().unwrap().visit(tf);
-                Self::SetOpts(new_value)
+                //let new_value = node.into_set_opts().unwrap().visit(tf);
+                node.into_set_opts().unwrap().visit(tf);
+                //Self::SetOpts(new_value)
             }
         }
     }
@@ -1374,16 +1310,18 @@ pub struct OptValueType {
 }
 
 impl Visitor for OptValueType {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut opt_node = Node::OptType(&mut self.opt_type);
         tf.trans(&mut opt_node);
-        let opt_type = opt_node.into_opt_type().unwrap().visit(tf);
+        //let opt_type = opt_node.into_opt_type().unwrap().visit(tf);
+        opt_node.into_opt_type().unwrap().visit(tf);
 
         let mut set_node = Node::SetVariable(&mut self.set_var);
         tf.trans(&mut set_node);
-        let set_var = set_node.into_set_variable().unwrap().visit(tf);
+        //let set_var = set_node.into_set_variable().unwrap().visit(tf);
+        set_node.into_set_variable().unwrap().visit(tf);
 
-        Self { opt_type, set_var }
+        //Self { opt_type, set_var }
     }
 }
 
@@ -1394,26 +1332,26 @@ pub struct Transaction {
 }
 
 impl Visitor for Transaction {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
-        let mode = match &mut self.mode {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
+        match &mut self.mode {
             Some(mode) => {
                 let mut node = Node::TransactionType(mode);
                 tf.trans(&mut node);
-                Some(node.into_transaction_type().unwrap().visit(tf))
+                node.into_transaction_type().unwrap().visit(tf)
             }
-            None => None,
+            None => {},
         };
 
-        let isolation_level = match &mut self.isolation_level {
+        match &mut self.isolation_level {
             Some(level) => {
                 let mut node = Node::IsolationType(level);
                 tf.trans(&mut node);
-                Some(node.into_isolation_type().unwrap().visit(tf))
+                node.into_isolation_type().unwrap().visit(tf)
             }
-            None => None,
+            None => {},
         };
 
-        Self { mode, isolation_level }
+        //Self { mode, isolation_level }
     }
 }
 
@@ -1424,9 +1362,7 @@ pub enum TransactionType {
 }
 
 impl Visitor for TransactionType {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) {}
 }
 
 #[derive(Debug, Clone)]
@@ -1438,9 +1374,7 @@ pub enum IsolationType {
 }
 
 impl Visitor for IsolationType {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) {}
 }
 
 #[derive(Debug, Clone)]
@@ -1450,19 +1384,21 @@ pub enum FollowingOptType {
 }
 
 impl Visitor for FollowingOptType {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         match self {
             Self::TypeEq(value) => {
                 let mut node = Node::FollowingOptTypeEq(value);
                 tf.trans(&mut node);
-                let new_value = node.into_following_opt_type_eq().unwrap().visit(tf);
-                Self::TypeEq(new_value)
+                //let new_value = node.into_following_opt_type_eq().unwrap().visit(tf);
+                node.into_following_opt_type_eq().unwrap().visit(tf);
+                //Self::TypeEq(new_value)
             }
             Self::Transaction(value) => {
                 let mut node = Node::Transaction(value);
                 tf.trans(&mut node);
-                let new_value = node.into_transaction().unwrap().visit(tf);
-                Self::Transaction(new_value)
+                node.into_transaction().unwrap().visit(tf);
+                //let new_value = node.into_transaction().unwrap().visit(tf);
+                //Self::Transaction(new_value)
             }
         }
     }
@@ -1475,20 +1411,22 @@ pub struct FollowingOptTypeEq {
 }
 
 impl Visitor for FollowingOptTypeEq {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut opt_node = Node::SetVariable(&mut self.opt_type);
         tf.trans(&mut opt_node);
-        let opt_type = opt_node.into_set_variable().unwrap().visit(tf);
+        //let opt_type = opt_node.into_set_variable().unwrap().visit(tf);
+        opt_node.into_set_variable().unwrap().visit(tf);
 
-        let mut values = Vec::with_capacity(self.values.len());
+        //let mut values = Vec::with_capacity(self.values.len());
         for v in self.values.iter_mut() {
             let mut node = Node::OptValue(v);
             tf.trans(&mut node);
-            let value = node.into_opt_value().unwrap().visit(tf);
-            values.push(value)
+            //let value = node.into_opt_value().unwrap().visit(tf);
+            node.into_opt_value().unwrap().visit(tf);
+            //values.push(value)
         }
 
-        Self { opt_type, values }
+        //Self { opt_type, values }
     }
 }
 
@@ -1499,16 +1437,18 @@ pub struct OptTypeFollowing {
 }
 
 impl Visitor for OptTypeFollowing {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut opt_node = Node::OptType(&mut self.opt_type);
         tf.trans(&mut opt_node);
-        let opt_type = opt_node.into_opt_type().unwrap().visit(tf);
+        //let opt_type = opt_node.into_opt_type().unwrap().visit(tf);
+        opt_node.into_opt_type().unwrap().visit(tf);
 
         let mut following_node = Node::FollowingOptType(&mut self.following);
         tf.trans(&mut following_node);
-        let following = following_node.into_following_opt_type().unwrap().visit(tf);
+        //let following = following_node.into_following_opt_type().unwrap().visit(tf);
+        following_node.into_following_opt_type().unwrap().visit(tf);
 
-        Self { opt_type, following }
+        //Self { opt_type, following }
     }
 }
 
@@ -1540,12 +1480,12 @@ impl OrderExpr {
 }
 
 impl Visitor for OrderExpr {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node_expr = Node::Expr(&mut self.expr);
         tf.trans(&mut node_expr);
-        let new_node_expr = node_expr.into_expr().unwrap();
-        self.expr = new_node_expr.visit(tf);
-        self.clone()
+        node_expr.into_expr().unwrap().visit(tf);
+        //self.expr = new_node_expr.visit(tf);
+        //self.clone()
     }
 }
 
@@ -1646,17 +1586,18 @@ impl AggExpr {
 }
 
 impl Visitor for AggExpr {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
-        let mut new_exprs = Vec::with_capacity(self.exprs.len());
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
+        //let mut new_exprs = Vec::with_capacity(self.exprs.len());
         for v in self.exprs.iter_mut() {
             let mut node = Node::Expr(v);
             tf.trans(&mut node);
 
-            new_exprs.push(node.into_expr().unwrap().visit(tf));
+            //new_exprs.push(node.into_expr().unwrap().visit(tf));
+            node.into_expr().unwrap().visit(tf);
         }
 
-        self.exprs = new_exprs;
-        self.clone()
+        //self.exprs = new_exprs;
+        //self.clone()
     }
 }
 
@@ -1707,8 +1648,8 @@ mod test {
     fn test_value_text(s: &mut S) {
         let mut val = Value::Text { span: Span::new(1, 1), value: "test".to_string() };
 
-        let new_val = val.visit(s);
-        if let Value::Text { span: _, value } = new_val {
+        val.visit(s);
+        if let Value::Text { span: _, value } = val {
             assert_eq!(value, "trans")
         }
     }
@@ -1716,8 +1657,8 @@ mod test {
     fn test_value_num(s: &mut S) {
         let mut val = Value::Num { span: Span::new(1, 1), value: "1".to_string(), signed: false };
 
-        let new_val = val.visit(s);
-        if let Value::Num { span: _, value, signed: _ } = new_val {
+        val.visit(s);
+        if let Value::Num { span: _, value, signed: _ } = val {
             assert_eq!(value, "2")
         }
     }
@@ -1729,8 +1670,8 @@ mod test {
         };
 
         s.is_default = true;
-        let new_val = val.visit(s);
-        if let Value::Default { span: _, value } = new_val {
+        val.visit(s);
+        if let Value::Default { span: _, value } = val {
             if let Value::Text { span: _, value } = *value {
                 assert_eq!(value, "default")
             }

--- a/pisa-proxy/parser/mysql/src/ast/dml.rs
+++ b/pisa-proxy/parser/mysql/src/ast/dml.rs
@@ -65,10 +65,7 @@ impl SelectStmt {
 }
 
 impl Visitor for SelectStmt {
-    fn visit<T>(&mut self, tf: &mut T) -> Self
-    where
-        T: Transformer,
-    {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         match self {
             Self::Query(query) => {
                 let mut node = Node::Query(query);
@@ -76,15 +73,15 @@ impl Visitor for SelectStmt {
 
                 let new_node = node.into_query().unwrap(); 
                 if is_skip {
-                    *self = Self::Query(Box::new(new_node.clone()));
-                    tf.complete(&mut Node::SelectStmt(self));
-                    return self.clone();
+                    //*self = Self::Query(Box::new(new_node.clone()));
+                    tf.complete(&mut Node::Query(new_node));
+                    return;
                 }
 
-                let new_node = new_node.visit(tf);
-                *self = Self::Query(Box::new(new_node));
-                tf.complete(&mut Node::SelectStmt(self));
-                self.clone()
+                new_node.visit(tf);
+                //*self = Self::Query(Box::new(new_node));
+                tf.complete(&mut Node::Query(new_node));
+                //self.clone()
             }
 
             Self::SubQuery(query) => {
@@ -93,47 +90,49 @@ impl Visitor for SelectStmt {
 
                 let new_node = node.into_sub_query().unwrap(); 
                 if is_skip {
-                    *self = Self::SubQuery(Box::new(new_node.clone()));
-                    tf.complete(&mut Node::SelectStmt(self));
-                    return self.clone();
+                    //*self = Self::SubQuery(Box::new(new_node.clone()));
+                    tf.complete(&mut Node::SubQuery(new_node));
+                    return;
                 }
 
-                let new_node = new_node.visit(tf);
-                *self = Self::SubQuery(Box::new(new_node));
-                tf.complete(&mut Node::SelectStmt(self));
-                self.clone()
+                new_node.visit(tf);
+                //*self = Self::SubQuery(Box::new(new_node));
+                tf.complete(&mut Node::SubQuery(new_node));
+                //self.clone()
             }
 
             Self::With(query) => {
                 let mut node = Node::WithQuery(query);
                 tf.trans(&mut node);
 
-                let new_node = node.into_with_query().unwrap().visit(tf);
-                Self::With(Box::new(new_node))
+                //let new_node = node.into_with_query().unwrap().visit(tf);
+                node.into_with_query().unwrap().visit(tf);
+                //Self::With(Box::new(new_node))
             }
 
             Self::ValueConstructor(exprs) => {
-                let mut new_exprs = Vec::with_capacity(exprs.len());
+                //let mut new_exprs = Vec::with_capacity(exprs.len());
 
                 for v in exprs {
-                    let mut sub_new_exprs = Vec::with_capacity(v.len());
+                    //let mut sub_new_exprs = Vec::with_capacity(v.len());
                     for vv in v {
                         let mut node = Node::Expr(vv);
                         tf.trans(&mut node);
 
-                        let new_node = node.into_expr().unwrap().visit(tf);
-                        sub_new_exprs.push(new_node);
+                        //let new_node = node.into_expr().unwrap().visit(tf);
+                        node.into_expr().unwrap().visit(tf);
+                        //sub_new_exprs.push(new_node);
                     }
 
-                    new_exprs.push(sub_new_exprs);
+                    //new_exprs.push(sub_new_exprs);
                 }
 
-                Self::ValueConstructor(new_exprs)
+                //Self::ValueConstructor(new_exprs)
             }
 
-            Self::ExplicitTable(table) => Self::ExplicitTable(table.clone()),
+            Self::ExplicitTable(_) => {},
 
-            Self::None => Self::None,
+            Self::None => {},
         }
     }
 }
@@ -220,90 +219,98 @@ impl Query {
 }
 
 impl Visitor for Query {
-    fn visit<T>(&mut self, tf: &mut T) -> Self
-    where
-        T: Transformer,
-    {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut items = Node::Items(&mut self.items);
         let is_skip = tf.trans(&mut items);
         let new_items = items.into_items().unwrap();
         if is_skip {
             tf.complete(&mut Node::Items(new_items));
-            self.items = new_items.clone();
+            //self.items = new_items.clone();
         } else {
-            let new_items = new_items.visit(tf);
-            self.items = new_items;
+            //let new_items = new_items.visit(tf);
+            new_items.visit(tf);
+            //self.items = new_items;
         }
 
         if let Some(v) = &mut self.into_clause {
             let mut node = Node::IntoClause(v);
             tf.trans(&mut node);
-            self.into_clause = Some(node.into_into_clause().unwrap().visit(tf));
+            node.into_into_clause().unwrap().visit(tf);
+            //self.into_clause = Some(node.into_into_clause().unwrap().visit(tf));
         }
 
         if let Some(v) = &mut self.from_clause {
             let mut node = Node::FromClause(v);
             tf.trans(&mut node);
-            self.from_clause = Some(node.into_from_clause().unwrap().visit(tf));
+            //self.from_clause = Some(node.into_from_clause().unwrap().visit(tf));
+            node.into_from_clause().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.where_clause {
             let mut node = Node::WhereClause(v);
             tf.trans(&mut node);
-            self.where_clause = Some(node.into_where_clause().unwrap().visit(tf));
+            //self.where_clause = Some(node.into_where_clause().unwrap().visit(tf));
+            node.into_where_clause().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.group_clause {
             let mut node = Node::GroupClause(v);
             tf.trans(&mut node);
-            self.group_clause = Some(node.into_group_clause().unwrap().visit(tf));
+            //self.group_clause = Some(node.into_group_clause().unwrap().visit(tf));
+            node.into_group_clause().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.having_clause {
             let mut node = Node::HavingClause(v);
             tf.trans(&mut node);
-            self.having_clause = Some(node.into_having_clause().unwrap().visit(tf));
+            //self.having_clause = Some(node.into_having_clause().unwrap().visit(tf));
+            node.into_having_clause().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.window_clause {
             let mut node = Node::WindowClause(v);
             tf.trans(&mut node);
-            self.window_clause = Some(node.into_window_clause().unwrap().visit(tf));
+            //self.window_clause = Some(node.into_window_clause().unwrap().visit(tf));
+            node.into_window_clause().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.order_clause {
             let mut node = Node::OrderClause(v);
             tf.trans(&mut node);
-            self.order_clause = Some(node.into_order_clause().unwrap().visit(tf));
+            //self.order_clause = Some(node.into_order_clause().unwrap().visit(tf));
+            node.into_order_clause().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.limit_clause {
             let mut node = Node::LimitClause(v);
             tf.trans(&mut node);
-            self.limit_clause = Some(node.into_limit_clause().unwrap().visit(tf));
+            //self.limit_clause = Some(node.into_limit_clause().unwrap().visit(tf));
+            node.into_limit_clause().unwrap().visit(tf);
         }
 
-        let mut new_locks = Vec::with_capacity(self.lock_clauses.len());
+        //let mut new_locks = Vec::with_capacity(self.lock_clauses.len());
 
         for v in self.lock_clauses.iter_mut() {
             let mut node = Node::LockClause(v);
             tf.trans(&mut node);
-            let new_node = node.into_lock_clause().unwrap();
-            new_locks.push(new_node.visit(tf))
+            //let new_node = node.into_lock_clause().unwrap();
+            node.into_lock_clause().unwrap().visit(tf);
+            //new_locks.push(new_node.visit(tf))
         }
 
-        if !new_locks.is_empty() {
-            self.lock_clauses = new_locks
-        }
+        //if !new_locks.is_empty() {
+        //    self.lock_clauses = new_locks
+        //}
 
         if let Some(union) = &mut self.union_query {
             let mut node = Node::SelectStmt(union);
             tf.trans(&mut node);
-            let new_node = node.into_select_stmt().unwrap().visit(tf);
-            self.union_query = Some(Box::new(new_node));
+            //let new_node = node.into_select_stmt().unwrap().visit(tf);
+            node.into_select_stmt().unwrap().visit(tf);
+            //self.union_query = Some(Box::new(new_node));
         }
 
-        self.clone()
+        //self.clone()
     }
 }
 
@@ -374,12 +381,9 @@ impl Items {
 }
 
 impl Visitor for Items {
-    fn visit<T>(&mut self, tf: &mut T) -> Self
-    where
-        T: Transformer,
-    {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
+        //let mut new_items = Vec::with_capacity(self.items.len());
 
-        let mut new_items = Vec::with_capacity(self.items.len());
         for v in self.items.iter_mut() {
             let mut node = Node::Item(v);
             let is_skip = tf.trans(&mut node);
@@ -387,16 +391,17 @@ impl Visitor for Items {
 
             if is_skip {
                 tf.complete(&mut Node::Item(new_node));
-                new_items.push(new_node.clone());
+                //new_items.push(new_node.clone());
                 continue;
             }
             
-            new_items.push(new_node.visit(tf));
+            //new_items.push(new_node.visit(tf));
+            new_node.visit(tf);
         }
 
-        self.items = new_items;
+        //self.items = new_items;
 
-        self.clone()
+        //self.clone()
     }
 }
 
@@ -421,14 +426,15 @@ impl Item {
 }
 
 impl Visitor for Item {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         match self {
-            Self::Wild(val) => Item::Wild(*val),
+            Self::Wild(_val) => {},
             Self::TableWild(wild) => {
                 let mut node = Node::TableWild(wild);
                 tf.trans(&mut node);
-                let new_node = node.into_table_wild().unwrap();
-                Item::TableWild(new_node.visit(tf))
+                //let new_node = node.into_table_wild().unwrap();
+                node.into_table_wild().unwrap().visit(tf);
+                //Item::TableWild(new_node.visit(tf))
             }
             Self::ItemExpr(item) => {
                 let mut node = Node::ItemExpr(item);
@@ -436,9 +442,11 @@ impl Visitor for Item {
                 let new_node = node.into_item_expr().unwrap();
                 if is_skip {
                     tf.complete(&mut Node::ItemExpr(new_node));
-                    return Item::ItemExpr(Box::new(new_node.clone()));
+                    //return Item::ItemExpr(Box::new(new_node.clone()));
+                    return
                 }
-                Item::ItemExpr(Box::new(new_node.visit(tf)))
+                //Item::ItemExpr(Box::new(new_node.visit(tf)))
+                new_node.visit(tf);
             }
         }
     }
@@ -467,9 +475,7 @@ impl TableWild {
 }
 
 impl Visitor for TableWild {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) { }
 }
 
 #[derive(Debug, Clone)]
@@ -494,14 +500,15 @@ impl ItemExpr {
 }
 
 impl Visitor for ItemExpr {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node = Node::Expr(&mut self.expr);
         tf.trans(&mut node);
 
-        let new_node = node.into_expr().unwrap().visit(tf);
-        self.expr = new_node;
+        //let new_node = node.into_expr().unwrap().visit(tf);
+        node.into_expr().unwrap().visit(tf);
+        //self.expr = new_node;
 
-        self.clone()
+        //self.clone()
     }
 }
 
@@ -532,9 +539,7 @@ impl LockClause {
 }
 
 impl Visitor for LockClause {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) { }
 }
 
 #[derive(Debug, Clone)]
@@ -595,30 +600,27 @@ impl IntoClause {
 }
 
 impl Visitor for IntoClause {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         match self {
             Self::OutFile(out) => {
                 let mut n = Node::OutFile(out);
                 tf.trans(&mut n);
-                Self::OutFile(n.into_out_file().unwrap().visit(tf))
+                n.into_out_file().unwrap().visit(tf);
             }
 
             Self::DumpFile(dump) => {
                 let mut n = Node::DumpFile(dump);
                 tf.trans(&mut n);
-                Self::DumpFile(n.into_dump_file().unwrap().visit(tf))
+                n.into_dump_file().unwrap().visit(tf);
             }
 
             Self::Vars(vars) => {
-                let mut new_vars = Vec::with_capacity(vars.len());
-
                 for v in vars {
                     let mut node = Node::Value(v);
                     tf.trans(&mut node);
 
-                    new_vars.push(node.into_value().unwrap().visit(tf))
+                    node.into_value().unwrap().visit(tf);
                 }
-                Self::Vars(new_vars)
             }
         }
     }
@@ -657,9 +659,7 @@ impl OutFile {
 }
 
 impl Visitor for OutFile {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) { }
 }
 
 #[derive(Debug, Clone)]
@@ -678,9 +678,7 @@ impl DumpFile {
 }
 
 impl Visitor for DumpFile {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T)  { }
 }
 
 #[derive(Debug, Clone)]
@@ -707,20 +705,15 @@ impl FromClause {
 }
 
 impl Visitor for FromClause {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         match self {
-            Self::Dual => {
-                FromClause::Dual
-            }
+            Self::Dual => {}
             Self::TableRefs(refs) => {
-                let mut new_refs = Vec::with_capacity(refs.len());
                 for v in refs {
                     let mut node = Node::TableRef(v);
                     tf.trans(&mut node);
-                    let new_node = node.into_table_ref().unwrap();
-                    new_refs.push(new_node.visit(tf).clone());
+                    node.into_table_ref().unwrap().visit(tf);
                 }
-                FromClause::TableRefs(new_refs)
             }
         }
     }
@@ -757,34 +750,30 @@ impl TableRef {
 }
 
 impl Visitor for TableRef {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         match self {
             Self::TableFactor(factor) => {
                 let mut n = Node::TableFactor(factor);
                 tf.trans(&mut n);
-                let new_node = n.into_table_factor().unwrap();
-                TableRef::TableFactor(Box::new(new_node.visit(tf)))
+                n.into_table_factor().unwrap().visit(tf);
             }
 
             Self::JoinedTable(joined) => {
                 let mut n = Node::JoinedTable(joined);
                 tf.trans(&mut n);
-                let new_node = n.into_joined_table().unwrap();
-                TableRef::JoinedTable(Box::new(new_node.visit(tf)))
+                n.into_joined_table().unwrap().visit(tf);
             }
 
             Self::OjTableFactor(factor) => {
                 let mut n = Node::TableFactor(factor);
                 tf.trans(&mut n);
-                let new_node = n.into_table_factor().unwrap();
-                TableRef::OjTableFactor(Box::new(new_node.visit(tf)))
+                n.into_table_factor().unwrap().visit(tf);
             }
 
             Self::OjJoinedTable(joined) => {
                 let mut n = Node::JoinedTable(joined);
                 tf.trans(&mut n);
-                let new_node = n.into_joined_table().unwrap();
-                TableRef::OjJoinedTable(Box::new(new_node.visit(tf)))
+                n.into_joined_table().unwrap().visit(tf);
             }
         }
     }
@@ -847,53 +836,44 @@ impl TableFactor {
 }
 
 impl Visitor for TableFactor {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         match self {
             Self::SingleTable(st) => {
                 let mut n = Node::SingleTable(st);
                 tf.trans(&mut n);
-                let new_node = n.into_single_table().unwrap();
-                TableFactor::SingleTable(new_node.visit(tf))
+                n.into_single_table().unwrap().visit(tf);
             }
 
             Self::SingleTableParens(stp) => {
                 let mut node = Node::SingleTable(stp);
                 tf.trans(&mut node);
-                let new_node = node.into_single_table().unwrap();
-                TableFactor::SingleTableParens(new_node.visit(tf))
+                node.into_single_table().unwrap().visit(tf);
             }
 
             Self::DerivedTable(dt) => {
                 let mut node = Node::DerivedTable(dt);
                 tf.trans(&mut node);
-                let new_node = node.into_derived_table().unwrap();
-                TableFactor::DerivedTable(new_node.visit(tf))
+                node.into_derived_table().unwrap().visit(tf);
             }
 
             Self::JoinedTableParens(jtp) => {
                 let mut node = Node::JoinedTable(jtp);
                 tf.trans(&mut node);
-                let new_node = node.into_joined_table().unwrap();
-                TableFactor::JoinedTableParens(Box::new(new_node.visit(tf)))
+                node.into_joined_table().unwrap().visit(tf);
             }
 
             Self::TableRefsParens(refs) => {
-                let mut new_refs = Vec::with_capacity(refs.len());
                 for v in refs {
                     let mut node = Node::TableRef(v);
                     tf.trans(&mut node);
-                    let new_node = node.into_table_ref().unwrap();
-                    new_refs.push(new_node.visit(tf));
+                    node.into_table_ref().unwrap().visit(tf);
                 }
-
-                TableFactor::TableRefsParens(new_refs)
             }
 
             Self::TableFunc(func) => {
                 let mut node = Node::TableFunc(func);
                 tf.trans(&mut node);
-                let new_node = node.into_table_func().unwrap();
-                TableFactor::TableFunc(new_node.visit(tf))
+                node.into_table_func().unwrap().visit(tf);
             }
         }
     }
@@ -937,19 +917,7 @@ impl SingleTable {
 }
 
 impl Visitor for SingleTable {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        //let mut new_hints = Vec::with_capacity(self.index_hints.len());
-        //for v in &self.index_hints {
-        //    let mut node = Node::IndexHint(v.clone());
-        //    tf.trans(&mut node);
-        //    new_hints.push(node.into_index_hint().unwrap().visit(tf));
-        //}
-
-        //if !new_hints.is_empty() {
-        //    self.index_hints = new_hints;
-        //}
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) { }
 }
 
 #[derive(Debug, Clone)]
@@ -975,9 +943,7 @@ impl TableIdent {
 }
 
 impl Visitor for TableIdent {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) { }
 }
 
 
@@ -994,20 +960,18 @@ impl SingleTableParens {
 }
 
 impl Visitor for SingleTableParens {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         match self {
             Self::SingleTable(st) => {
                 let mut node = Node::SingleTable(st);
                 tf.trans(&mut node);
-                let new_node = node.into_single_table().unwrap();
-                SingleTableParens::SingleTable(new_node.visit(tf))
+                node.into_single_table().unwrap().visit(tf);
             }
 
             Self::SingleTableParens(stp) => {
                 let mut node = Node::SingleTableParens(stp);
                 tf.trans(&mut node);
-                let new_node = node.into_single_table_parens().unwrap();
-                SingleTableParens::SingleTableParens(Box::new(new_node.visit(tf)))
+                node.into_single_table_parens().unwrap().visit(tf);
             }
         }
     }
@@ -1050,9 +1014,8 @@ impl DerivedTable {
 }
 
 impl Visitor for DerivedTable {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
-        self.subquery = self.subquery.visit(tf);
-        self.clone()
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
+        self.subquery.visit(tf);
     }
 }
 
@@ -1072,35 +1035,27 @@ impl IndexHint {
 }
 
 impl Visitor for IndexHint {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node_hint_type = Node::Value(&mut self.hint_type);
         tf.trans(&mut node_hint_type);
-        self.hint_type = node_hint_type.into_value().unwrap().visit(tf);
+        node_hint_type.into_value().unwrap().visit(tf);
 
         let mut node_key = Node::Value(&mut self.key_or_index);
         tf.trans(&mut node_key);
-        self.key_or_index = node_key.into_value().unwrap().visit(tf);
+        node_key.into_value().unwrap().visit(tf);
 
         if let Some(hint) = &mut self.hint_clause {
             let mut node = Node::Value(hint);
 
             tf.trans(&mut node);
-            self.hint_clause = Some(node.into_value().unwrap().visit(tf));
+            node.into_value().unwrap().visit(tf);
         }
 
-        let mut new_keys = Vec::with_capacity(self.keys.len());
         for v in self.keys.iter_mut() {
             let mut node = Node::Value(v);
             tf.trans(&mut node);
-            let new_node = node.into_value().unwrap();
-            new_keys.push(new_node.visit(tf));
+            node.into_value().unwrap().visit(tf);
         }
-
-        if !new_keys.is_empty() {
-            self.keys = new_keys;
-        }
-
-        self.clone()
     }
 }
 
@@ -1136,16 +1091,14 @@ impl TableFunc {
 }
 
 impl Visitor for TableFunc {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node_expr = Node::Expr(&mut self.expr);
         tf.trans(&mut node_expr);
-        self.expr = node_expr.into_expr().unwrap().visit(tf);
+        node_expr.into_expr().unwrap().visit(tf);
 
         let mut node_text = Node::Value(&mut self.text);
         tf.trans(&mut node_text);
-        self.text = node_text.into_value().unwrap().visit(tf);
-
-        self.clone()
+        node_text.into_value().unwrap().visit(tf);
     }
 }
 
@@ -1189,22 +1142,20 @@ impl JoinedTable {
 }
 
 impl Visitor for JoinedTable {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node_left = Node::TableRef(&mut self.left);
         tf.trans(&mut node_left);
-        self.left = node_left.into_table_ref().unwrap().visit(tf);
+        node_left.into_table_ref().unwrap().visit(tf);
 
         let mut node_right = Node::TableRef(&mut self.right);
         tf.trans(&mut node_right);
-        self.right = node_right.into_table_ref().unwrap().visit(tf);
+        node_right.into_table_ref().unwrap().visit(tf);
 
         if let Some(expr) = &mut self.on_cond {
             let mut node_expr = Node::Expr(expr);
             tf.trans(&mut node_expr);
-            self.on_cond = Some(Box::new(node_expr.into_expr().unwrap().visit(tf)));
+            node_expr.into_expr().unwrap().visit(tf);
         }
-
-        self.clone()
     }
 }
 
@@ -1223,14 +1174,11 @@ impl WhereClause {
 }
 
 impl Visitor for WhereClause {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node_expr = Node::Expr(&mut self.expr);
         tf.trans(&mut node_expr);
 
-        let new_node_expr = node_expr.into_expr().unwrap();
-        self.expr = Box::new(new_node_expr.visit(tf));
-
-        self.clone()
+        node_expr.into_expr().unwrap().visit(tf);
     }
 }
 
@@ -1257,20 +1205,13 @@ impl GroupClause {
 }
 
 impl Visitor for GroupClause {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
-        let mut new_exprs = Vec::with_capacity(self.exprs.len());
-
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         for v in &mut self.exprs {
             let mut node_expr = Node::Expr(v);
             tf.trans(&mut node_expr);
 
-            let new_node_expr = node_expr.into_expr().unwrap();
-            new_exprs.push(new_node_expr.visit(tf));
+            node_expr.into_expr().unwrap().visit(tf);
         }
-
-        self.exprs = new_exprs;
-
-        self.clone()
     }
 }
 
@@ -1289,13 +1230,11 @@ impl HavingClause {
 }
 
 impl Visitor for HavingClause {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node_expr = Node::Expr(&mut self.expr);
         tf.trans(&mut node_expr);
 
-        let new_node_expr = node_expr.into_expr().unwrap();
-        self.expr = Box::new(new_node_expr.visit(tf));
-        self.clone()
+        node_expr.into_expr().unwrap().visit(tf);
     }
 }
 
@@ -1317,19 +1256,13 @@ impl WindowClause {
 }
 
 impl Visitor for WindowClause {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
-        let mut new_defs = Vec::with_capacity(self.defs.len());
-
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         for v in &mut self.defs {
             let mut node = Node::WindowDef(v);
             tf.trans(&mut node);
 
-            let new_node = node.into_window_def().unwrap();
-            new_defs.push(new_node.visit(tf));
+            node.into_window_def().unwrap().visit(tf);
         }
-
-        self.defs = new_defs;
-        self.clone()
     }
 }
 
@@ -1349,9 +1282,7 @@ impl WindowDef {
 }
 
 impl Visitor for WindowDef {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) { }
 }
 
 // `WindowSpec` struct unused yet
@@ -1371,48 +1302,31 @@ impl WindowSpec {
 }
 
 impl Visitor for WindowSpec {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         if let Some(name) = &mut self.name {
             let mut node = Node::Value(name);
             tf.trans(&mut node);
 
-            let new_node = node.into_value().unwrap();
-            self.name = Some(new_node.visit(tf));
+            node.into_value().unwrap().visit(tf);
         }
 
-        let mut new_exprs = Vec::with_capacity(self.partition_clause.len());
         for v in &mut self.partition_clause {
             let mut node = Node::Expr(v);
             tf.trans(&mut node);
-            let new_node = node.into_expr().unwrap();
-            new_exprs.push(new_node.visit(tf));
+            node.into_expr().unwrap().visit(tf);
         }
-
-        if !new_exprs.is_empty() {
-            self.partition_clause = new_exprs;
-        }
-
-        let mut new_orders = Vec::with_capacity(self.window_order_clause.len());
 
         for v in &mut self.window_order_clause {
             let mut node = Node::OrderExpr(v);
             tf.trans(&mut node);
-            let new_node = node.into_order_expr().unwrap();
-            new_orders.push(new_node.visit(tf));
-        }
-
-        if !new_orders.is_empty() {
-            self.window_order_clause = new_orders;
+            node.into_order_expr().unwrap().visit(tf);
         }
 
         if let Some(frame) = &mut self.window_frame_clause {
             let mut node = Node::WindowFrameClause(frame);
             tf.trans(&mut node);
-            let new_node = node.into_window_frame_clause().unwrap();
-            self.window_frame_clause = Some(new_node.visit(tf));
+            node.into_window_clause().unwrap().visit(tf);
         }
-
-        self.clone()
     }
 }
 
@@ -1429,9 +1343,7 @@ impl WindowFrameClause {
 }
 
 impl Visitor for WindowFrameClause {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) { }
 }
 
 #[derive(Debug, Clone)]
@@ -1452,20 +1364,12 @@ impl OrderClause {
 }
 
 impl Visitor for OrderClause {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
-        let mut new_orders = Vec::with_capacity(self.orders.len());
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         for v in &mut self.orders {
             let mut node = Node::OrderExpr(v);
             tf.trans(&mut node);
-            let new_node = node.into_order_expr().unwrap();
-            new_orders.push(new_node.visit(tf).clone());
+            node.into_order_expr().unwrap().visit(tf);
         }
-
-        if !new_orders.is_empty() {
-            self.orders = new_orders
-        }
-
-        self.clone()
     }
 }
 
@@ -1499,9 +1403,7 @@ impl LimitClause {
 }
 
 impl Visitor for LimitClause {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) {}
 }
 
 #[derive(Debug, Clone)]
@@ -1534,38 +1436,34 @@ impl SubQuery {
 }
 
 impl Visitor for SubQuery {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node = Node::SelectStmt(&mut self.query);
         tf.trans(&mut node);
-        let new_node = node.into_select_stmt().unwrap();
-        self.query = new_node.visit(tf);
+        node.into_select_stmt().unwrap().visit(tf);
 
         if let Some(union) = &mut self.union_query {
             let mut node = Node::SelectStmt(union);
             tf.trans(&mut node);
-            let new_node = node.into_select_stmt().unwrap().visit(tf);
-            self.union_query = Some(Box::new(new_node));
+            node.into_select_stmt().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.into_clause {
             let mut node = Node::IntoClause(v);
             tf.trans(&mut node);
-            self.into_clause = Some(node.into_into_clause().unwrap().visit(tf));
+            node.into_into_clause().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.order_clause {
             let mut node = Node::OrderClause(v);
             tf.trans(&mut node);
-            self.order_clause = Some(node.into_order_clause().unwrap().visit(tf));
+            node.into_order_clause().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.limit_clause {
             let mut node = Node::LimitClause(v);
             tf.trans(&mut node);
-            self.limit_clause = Some(node.into_limit_clause().unwrap().visit(tf));
+            node.into_limit_clause().unwrap().visit(tf);
         }
-
-        self.clone()
     }
 }
 
@@ -1585,16 +1483,14 @@ impl WithQuery {
 }
 
 impl Visitor for WithQuery {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node = Node::WithClause(&mut self.with_clause);
         tf.trans(&mut node);
-        self.with_clause = node.into_with_clause().unwrap().visit(tf);
+        node.into_with_clause().unwrap().visit(tf);
 
         let mut node = Node::SelectStmt(&mut self.expr_body);
         tf.trans(&mut node);
-        self.expr_body = node.into_select_stmt().unwrap().visit(tf);
-
-        self.clone()
+        node.into_select_stmt().unwrap().visit(tf);
     }
 }
 
@@ -1621,20 +1517,12 @@ impl WithClause {
 }
 
 impl Visitor for WithClause {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
-        let mut new_exprs = Vec::with_capacity(self.with_exprs.len());
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         for v in &mut self.with_exprs {
             let mut node = Node::CommonTableExpr(v);
             tf.trans(&mut node);
-            let new_node = node.into_common_table_expr().unwrap();
-            new_exprs.push(new_node.visit(tf))
+            node.into_common_table_expr().unwrap().visit(tf);
         }
-
-        if !self.with_exprs.is_empty() {
-            self.with_exprs = new_exprs
-        }
-
-        self.clone()
     }
 }
 
@@ -1659,26 +1547,16 @@ impl CommonTableExpr {
 }
 
 impl Visitor for CommonTableExpr {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
-        let mut new_columns = Vec::with_capacity(self.columns.len());
-
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         for v in &mut self.columns {
             let mut node = Node::Value(v);
             tf.trans(&mut node);
-            let new_node = node.into_value().unwrap();
-            new_columns.push(new_node.visit(tf).clone())
-        }
-
-        if !new_columns.is_empty() {
-            self.columns = new_columns
+            node.into_value().unwrap().visit(tf);
         }
 
         let mut node_query = Node::SelectStmt(&mut self.subquery);
         tf.trans(&mut node_query);
-        let new_query = node_query.into_select_stmt().unwrap();
-        self.subquery = new_query.visit(tf);
-
-        self.clone()
+        node_query.into_select_stmt().unwrap().visit(tf);
     }
 }
 
@@ -1702,9 +1580,7 @@ impl FieldTerm {
 }
 
 impl Visitor for FieldTerm {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) { }
 }
 
 #[derive(Debug, Clone)]
@@ -1727,9 +1603,7 @@ impl LineTerm {
 }
 
 impl Visitor for LineTerm {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) { }
 }
 
 #[derive(Debug, Clone)]
@@ -1753,22 +1627,13 @@ impl FieldTermColumn {
 }
 
 impl Visitor for FieldTermColumn {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
-        let mut new_terms = Vec::with_capacity(self.terms.len());
-
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         for v in &mut self.terms {
             let mut node = Node::FieldTerm(v);
             tf.trans(&mut node);
 
-            let new_node = node.into_field_term().unwrap();
-            new_terms.push(new_node.visit(tf))
+            node.into_field_term().unwrap().visit(tf);
         }
-
-        if !new_terms.is_empty() {
-            self.terms = new_terms
-        }
-
-        self.clone()
     }
 }
 
@@ -1791,9 +1656,7 @@ impl CharsetName {
 }
 
 impl Visitor for CharsetName {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) { }
 }
 
 #[derive(Debug, Clone)]
@@ -1877,113 +1740,97 @@ impl FieldType {
 }
 
 impl Visitor for FieldType {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         match self {
             Self::FieldIntType(t) => {
                 let mut node = Node::FieldIntType(t);
                 tf.trans(&mut node);
-                FieldType::FieldIntType(node.into_field_int_type().unwrap().clone())
             }
 
             Self::FieldRealType(t) => {
                 let mut node = Node::FieldRealType(t);
                 tf.trans(&mut node);
-                FieldType::FieldRealType(node.into_field_real_type().unwrap().clone())
             }
 
             Self::FieldNumericType(t) => {
                 let mut node = Node::FieldNumericType(t);
                 tf.trans(&mut node);
-                FieldType::FieldNumericType(node.into_field_numeric_type().unwrap().clone())
             }
 
             Self::FieldBitType(t) => {
                 let mut node = Node::FieldBitType(t);
                 tf.trans(&mut node);
-                FieldType::FieldBitType(node.into_field_bit_type().unwrap().clone())
             }
 
-            Self::FieldBoolType => self.clone(),
-            Self::FieldBooleanType => self.clone(),
-            Self::FieldDateType => self.clone(),
+            Self::FieldBoolType => {},
+            Self::FieldBooleanType => {},
+            Self::FieldDateType => {},
 
             Self::FieldYearType(t) => {
                 let mut node = Node::FieldYearType(t);
                 tf.trans(&mut node);
-                FieldType::FieldYearType(node.into_field_year_type().unwrap().clone())
             }
 
             Self::FieldTimeType(t) => {
                 let mut node = Node::FieldTimeType(t);
                 tf.trans(&mut node);
-                FieldType::FieldTimeType(node.into_field_time_type().unwrap().clone())
             }
 
             Self::FieldTextType(t) => {
                 let mut node = Node::FieldTextType(t);
                 tf.trans(&mut node);
-                FieldType::FieldTextType(node.into_field_text_type().unwrap().clone())
             }
 
             Self::FieldBinaryType(t) => {
                 let mut node = Node::FieldBinaryType(t);
                 tf.trans(&mut node);
-                FieldType::FieldBinaryType(node.into_field_binary_type().unwrap().clone())
             }
 
             Self::FieldBlobType(t) => {
                 let mut node = Node::FieldBlobType(t);
                 tf.trans(&mut node);
-                FieldType::FieldBlobType(node.into_field_blob_type().unwrap().clone())
             }
 
             Self::FieldCharType(t) => {
                 let mut node = Node::FieldCharType(t);
                 tf.trans(&mut node);
-                FieldType::FieldCharType(node.into_field_char_type().unwrap().clone())
             }
 
             Self::FieldNCharType(t) => {
                 let mut node = Node::FieldNCharType(t);
                 tf.trans(&mut node);
-                FieldType::FieldNCharType(node.into_field_n_char_type().unwrap().clone())
             }
 
             Self::FieldVarCharType(t) => {
                 let mut node = Node::FieldVarCharType(t);
                 tf.trans(&mut node);
-                FieldType::FieldVarCharType(node.into_field_var_char_type().unwrap().clone())
             }
 
             Self::FieldNVarCharType(t) => {
                 let mut node = Node::FieldNVarCharType(t);
                 tf.trans(&mut node);
-                FieldType::FieldNVarCharType(node.into_field_n_var_char_type().unwrap().clone())
             }
 
             Self::FieldSetType(t) => {
                 let mut node = Node::FieldSetType(t);
                 tf.trans(&mut node);
-                FieldType::FieldSetType(node.into_field_set_type().unwrap().clone())
             }
 
             Self::FieldEnumType(t) => {
                 let mut node = Node::FieldEnumType(t);
                 tf.trans(&mut node);
-                FieldType::FieldEnumType(node.into_field_enum_type().unwrap().clone())
             }
 
             Self::FieldVarBinaryType(t) => {
                 let mut node = Node::FieldVarBinaryType(t);
                 tf.trans(&mut node);
-                FieldType::FieldVarBinaryType(node.into_field_var_binary_type().unwrap().clone())
             }
 
-            Self::FieldSpatialType(_t) => self.clone(),
+            Self::FieldSpatialType(_t) => {},
 
-            Self::FieldSerialType => self.clone(),
-            Self::FieldJsonType => self.clone(),
-            Self::FieldCastType(_) => self.clone(),
+            Self::FieldSerialType => {},
+            Self::FieldJsonType => {},
+            Self::FieldCastType(_) => {},
         }
     }
 }
@@ -2104,13 +1951,14 @@ impl FieldCharType {
 }
 
 impl Visitor for FieldCharType {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node = Node::CharsetOrBinary(&mut self.opt);
         tf.trans(&mut node);
 
-        self.opt = node.into_charset_or_binary().unwrap().visit(tf);
+        //self.opt = node.into_charset_or_binary().unwrap().visit(tf);
+        node.into_charset_or_binary().unwrap().visit(tf);
 
-        self.clone()
+        //self.clone()
     }
 }
 
@@ -2182,13 +2030,11 @@ impl FieldVarCharType {
 }
 
 impl Visitor for FieldVarCharType {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node = Node::CharsetOrBinary(&mut self.opt);
         tf.trans(&mut node);
 
-        self.opt = node.into_charset_or_binary().unwrap().visit(tf);
-
-        self.clone()
+        node.into_charset_or_binary().unwrap().visit(tf);
     }
 }
 
@@ -2308,13 +2154,11 @@ impl FieldBlobType {
 }
 
 impl Visitor for FieldBlobType {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node = Node::CharsetOrBinary(&mut self.opt);
         tf.trans(&mut node);
 
-        self.opt = node.into_charset_or_binary().unwrap().visit(tf);
-
-        self.clone()
+        node.into_charset_or_binary().unwrap().visit(tf);
     }
 }
 
@@ -2343,13 +2187,11 @@ impl FieldTextType {
 }
 
 impl Visitor for FieldTextType {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node = Node::CharsetOrBinary(&mut self.opt);
         tf.trans(&mut node);
 
-        self.opt = node.into_charset_or_binary().unwrap().visit(tf);
-
-        self.clone()
+        node.into_charset_or_binary().unwrap().visit(tf);
     }
 }
 
@@ -2374,13 +2216,11 @@ impl FieldSetType {
 }
 
 impl Visitor for FieldSetType {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node = Node::CharsetOrBinary(&mut self.opt);
         tf.trans(&mut node);
 
-        self.opt = node.into_charset_or_binary().unwrap().visit(tf);
-
-        self.clone()
+        node.into_charset_or_binary().unwrap().visit(tf);
     }
 }
 
@@ -2405,13 +2245,11 @@ impl FieldEnumType {
 }
 
 impl Visitor for FieldEnumType {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node = Node::CharsetOrBinary(&mut self.opt);
         tf.trans(&mut node);
 
-        self.opt = node.into_charset_or_binary().unwrap().visit(tf);
-
-        self.clone()
+        node.into_charset_or_binary().unwrap().visit(tf);
     }
 }
 
@@ -2494,46 +2332,41 @@ impl InsertStmt {
 }
 
 impl Visitor for InsertStmt {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         if let Some(fc) = &mut self.from_construct {
             let mut node = Node::InsertFromConstruct(fc);
             tf.trans(&mut node);
 
-            self.from_construct = Some(node.into_insert_from_construct().unwrap().visit(tf));
+            node.into_insert_from_construct().unwrap().visit(tf);
         }
 
         if let Some(vr) = &mut self.values_ref {
             let mut node = Node::ValuesRef(vr);
             tf.trans(&mut node);
 
-            self.values_ref = Some(node.into_values_ref().unwrap().visit(tf));
+            node.into_values_ref().unwrap().visit(tf);
         }
 
         if let Some(iu) = &mut self.ins_updates {
             let mut node = Node::InsUpdates(iu);
             tf.trans(&mut node);
 
-            self.ins_updates = Some(node.into_ins_updates().unwrap().visit(tf));
+            node.into_ins_updates().unwrap().visit(tf);
         }
 
-        let mut new_updates = Vec::with_capacity(self.updates.len());
         for v in self.updates.iter_mut() {
             let mut node = Node::UpdateElem(v);
             tf.trans(&mut node);
 
-            new_updates.push(node.into_update_elem().unwrap().visit(tf));
+            node.into_update_elem().unwrap().visit(tf);
         }
-
-        self.updates = new_updates;
 
         if let Some(qe) = &mut self.query_expr {
             let mut node = Node::InsertQueryExpr(qe);
             tf.trans(&mut node);
 
-            self.query_expr = Some(node.into_insert_query_expr().unwrap().visit(tf));
+            node.into_insert_query_expr().unwrap().visit(tf);
         }
-
-        self.clone()
     }
 }
 
@@ -2573,18 +2406,16 @@ impl UpdateElem {
 }
 
 impl Visitor for UpdateElem {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut new_var = Node::Value(&mut self.var_name);
         tf.trans(&mut new_var);
 
-        self.var_name = new_var.into_value().unwrap().visit(tf);
+        new_var.into_value().unwrap().visit(tf);
 
         let mut new_expr = Node::Expr(&mut self.expr);
         tf.trans(&mut new_expr);
 
-        self.expr = new_expr.into_expr().unwrap().visit(tf);
-
-        self.clone()
+        new_expr.into_expr().unwrap().visit(tf);
     }
 }
 
@@ -2609,18 +2440,13 @@ impl ValuesRef {
 }
 
 impl Visitor for ValuesRef {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
-        let mut new_dc = Vec::with_capacity(self.derived_columns.len());
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         for v in self.derived_columns.iter_mut() {
             let mut node = Node::Value(v);
             tf.trans(&mut node);
 
-            new_dc.push(node.into_value().unwrap().visit(tf));
+            node.into_value().unwrap().visit(tf);
         }
-
-        self.derived_columns = new_dc;
-
-        self.clone()
     }
 }
 
@@ -2642,18 +2468,13 @@ impl InsUpdates {
 }
 
 impl Visitor for InsUpdates {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
-        let mut new_updates = Vec::with_capacity(self.updates.len());
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         for v in self.updates.iter_mut() {
             let mut node = Node::UpdateElem(v);
             tf.trans(&mut node);
 
-            new_updates.push(node.into_update_elem().unwrap().visit(tf));
+            node.into_update_elem().unwrap().visit(tf);
         }
-
-        self.updates = new_updates;
-
-        self.clone()
     }
 }
 
@@ -2682,23 +2503,18 @@ impl InsertFromConstruct {
 }
 
 impl Visitor for InsertFromConstruct {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut new_values = Node::InsertVals(&mut self.values);
         tf.trans(&mut new_values);
 
-        self.values = new_values.into_insert_vals().unwrap().visit(tf);
+        new_values.into_insert_vals().unwrap().visit(tf);
 
-        let mut new_fields = Vec::with_capacity(self.fields.len());
         for v in self.fields.iter_mut() {
             let mut node = Node::InsertIdent(v);
             tf.trans(&mut node);
 
-            new_fields.push(node.into_insert_ident().unwrap().visit(tf));
+            node.into_insert_ident().unwrap().visit(tf);
         }
-
-        self.fields = new_fields;
-
-        self.clone()
     }
 }
 
@@ -2737,19 +2553,12 @@ impl InsertVals {
 }
 
 impl Visitor for InsertVals {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
-        let mut new_values = Vec::with_capacity(self.values.len());
-
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         for v in self.values.iter_mut() {
             let mut node = Node::RowValue(v);
             tf.trans(&mut node);
-            let new_node = node.into_row_value().unwrap().visit(tf);
-            new_values.push(new_node);
+            node.into_row_value().unwrap().visit(tf);
         }
-
-        self.values = new_values;
-
-        self.clone()
     }
 }
 
@@ -2773,22 +2582,15 @@ impl RowValue {
 
 
 impl Visitor for RowValue {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
-        let mut new_values = Vec::with_capacity(self.values.len());
-
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         for v in self.values.iter_mut() {
             let mut node = Node::Expr(v);
             tf.trans(&mut node);
 
-            let new_node = node.into_expr().unwrap().visit(tf);
-            new_values.push(new_node);
+            node.into_expr().unwrap().visit(tf);
         }
 
-        self.values = new_values;
-
         tf.complete(&mut Node::RowValue(self));
-
-        self.clone()
     }
 }
 
@@ -2809,20 +2611,20 @@ impl InsertIdent {
 }
 
 impl Visitor for InsertIdent {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         match self {
             Self::Ident(val) => {
                 let mut node = Node::Value(val);
                 tf.trans(&mut node);
 
-                Self::Ident(node.into_value().unwrap().visit(tf))
+                node.into_value().unwrap().visit(tf);
             }
 
             Self::TableWild(val) => {
                 let mut node = Node::TableWild(val);
                 tf.trans(&mut node);
 
-                Self::TableWild(node.into_table_wild().unwrap().visit(tf))
+                node.into_table_wild().unwrap().visit(tf);
             }
         }
     }
@@ -2855,23 +2657,18 @@ impl InsertQueryExpr {
 }
 
 impl Visitor for InsertQueryExpr {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut new_query = Node::SelectStmt(&mut self.query);
         tf.trans(&mut new_query);
 
-        self.query = new_query.into_select_stmt().unwrap().visit(tf);
+        new_query.into_select_stmt().unwrap().visit(tf);
 
-        let mut new_fields = Vec::with_capacity(self.fields.len());
         for v in self.fields.iter_mut() {
             let mut node = Node::InsertIdent(v);
             tf.trans(&mut node);
 
-            new_fields.push(node.into_insert_ident().unwrap().visit(tf));
+            node.into_insert_ident().unwrap().visit(tf);
         }
-
-        self.fields = new_fields;
-
-        self.clone()
     }
 }
 
@@ -2929,47 +2726,38 @@ impl UpdateStmt {
 }
 
 impl Visitor for UpdateStmt {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         if let Some(with) = &mut self.with_clause {
             let mut node = Node::WithClause(with);
             tf.trans(&mut node);
 
-            self.with_clause = Some(node.into_with_clause().unwrap().visit(tf));
+            node.into_with_clause().unwrap().visit(tf);
         }
 
-        let mut new_refs = Vec::with_capacity(self.table_refs.len());
         for v in self.table_refs.iter_mut() {
             let mut node = Node::TableRef(v);
             tf.trans(&mut node);
-            let new_node = node.into_table_ref().unwrap();
-            new_refs.push(new_node.visit(tf));
+            node.into_table_ref().unwrap().visit(tf);
         }
 
-        self.table_refs = new_refs;
-
-        let mut new_updates = Vec::with_capacity(self.updates.len());
         for v in self.updates.iter_mut() {
             let mut node = Node::UpdateElem(v);
             tf.trans(&mut node);
 
-            new_updates.push(node.into_update_elem().unwrap().visit(tf));
+            node.into_update_elem().unwrap().visit(tf);
         }
-
-        self.updates = new_updates;
 
         if let Some(v) = &mut self.where_clause {
             let mut node = Node::WhereClause(v);
             tf.trans(&mut node);
-            self.where_clause = Some(node.into_where_clause().unwrap().visit(tf));
+            node.into_where_clause().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.order_clause {
             let mut node = Node::OrderClause(v);
             tf.trans(&mut node);
-            self.order_clause = Some(node.into_order_clause().unwrap().visit(tf));
+            node.into_order_clause().unwrap().visit(tf);
         }
-
-        self.clone()
     }
 }
 
@@ -3067,37 +2855,31 @@ impl DeleteStmt {
 }
 
 impl Visitor for DeleteStmt {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         if let Some(with) = &mut self.with_clause {
             let mut node = Node::WithClause(with);
             tf.trans(&mut node);
 
-            self.with_clause = Some(node.into_with_clause().unwrap().visit(tf));
+            node.into_with_clause().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.where_clause {
             let mut node = Node::WhereClause(v);
             tf.trans(&mut node);
-            self.where_clause = Some(node.into_where_clause().unwrap().visit(tf));
+            node.into_where_clause().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.order_clause {
             let mut node = Node::OrderClause(v);
             tf.trans(&mut node);
-            self.order_clause = Some(node.into_order_clause().unwrap().visit(tf));
+            node.into_order_clause().unwrap().visit(tf);
         }
 
-        let mut new_refs = Vec::with_capacity(self.table_refs.len());
         for v in self.table_refs.iter_mut() {
             let mut node = Node::TableRef(v);
             tf.trans(&mut node);
-            let new_node = node.into_table_ref().unwrap();
-            new_refs.push(new_node.visit(tf));
+            node.into_table_ref().unwrap().visit(tf);
         }
-
-        self.table_refs = new_refs;
-
-        self.clone()
     }
 }
 
@@ -3121,12 +2903,10 @@ impl Prepare {
 }
 
 impl Visitor for Prepare {
-    fn visit<T: Transformer>(&mut self, tf: &mut T) -> Self {
+    fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node = Node::Value(&mut self.preparable_stmt);
         tf.trans(&mut node);
-        self.preparable_stmt = node.into_value().unwrap().visit(tf);
-
-        self.clone()
+        node.into_value().unwrap().visit(tf);
     }
 }
 
@@ -3162,9 +2942,7 @@ impl Deallocate {
 }
 
 impl Visitor for Deallocate {
-    fn visit<T: Transformer>(&mut self, _tf: &mut T) -> Self {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T)  { }
 }
 
 #[derive(Debug, Clone)]

--- a/pisa-proxy/parser/mysql/src/ast/dml.rs
+++ b/pisa-proxy/parser/mysql/src/ast/dml.rs
@@ -73,15 +73,12 @@ impl Visitor for SelectStmt {
 
                 let new_node = node.into_query().unwrap(); 
                 if is_skip {
-                    //*self = Self::Query(Box::new(new_node.clone()));
                     tf.complete(&mut Node::Query(new_node));
                     return;
                 }
 
                 new_node.visit(tf);
-                //*self = Self::Query(Box::new(new_node));
                 tf.complete(&mut Node::Query(new_node));
-                //self.clone()
             }
 
             Self::SubQuery(query) => {
@@ -90,44 +87,31 @@ impl Visitor for SelectStmt {
 
                 let new_node = node.into_sub_query().unwrap(); 
                 if is_skip {
-                    //*self = Self::SubQuery(Box::new(new_node.clone()));
                     tf.complete(&mut Node::SubQuery(new_node));
                     return;
                 }
 
                 new_node.visit(tf);
-                //*self = Self::SubQuery(Box::new(new_node));
                 tf.complete(&mut Node::SubQuery(new_node));
-                //self.clone()
             }
 
             Self::With(query) => {
                 let mut node = Node::WithQuery(query);
                 tf.trans(&mut node);
 
-                //let new_node = node.into_with_query().unwrap().visit(tf);
                 node.into_with_query().unwrap().visit(tf);
-                //Self::With(Box::new(new_node))
             }
 
             Self::ValueConstructor(exprs) => {
-                //let mut new_exprs = Vec::with_capacity(exprs.len());
-
                 for v in exprs {
-                    //let mut sub_new_exprs = Vec::with_capacity(v.len());
                     for vv in v {
                         let mut node = Node::Expr(vv);
                         tf.trans(&mut node);
 
-                        //let new_node = node.into_expr().unwrap().visit(tf);
                         node.into_expr().unwrap().visit(tf);
-                        //sub_new_exprs.push(new_node);
                     }
 
-                    //new_exprs.push(sub_new_exprs);
                 }
-
-                //Self::ValueConstructor(new_exprs)
             }
 
             Self::ExplicitTable(_) => {},
@@ -225,92 +209,69 @@ impl Visitor for Query {
         let new_items = items.into_items().unwrap();
         if is_skip {
             tf.complete(&mut Node::Items(new_items));
-            //self.items = new_items.clone();
         } else {
-            //let new_items = new_items.visit(tf);
             new_items.visit(tf);
-            //self.items = new_items;
         }
 
         if let Some(v) = &mut self.into_clause {
             let mut node = Node::IntoClause(v);
             tf.trans(&mut node);
             node.into_into_clause().unwrap().visit(tf);
-            //self.into_clause = Some(node.into_into_clause().unwrap().visit(tf));
         }
 
         if let Some(v) = &mut self.from_clause {
             let mut node = Node::FromClause(v);
             tf.trans(&mut node);
-            //self.from_clause = Some(node.into_from_clause().unwrap().visit(tf));
             node.into_from_clause().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.where_clause {
             let mut node = Node::WhereClause(v);
             tf.trans(&mut node);
-            //self.where_clause = Some(node.into_where_clause().unwrap().visit(tf));
             node.into_where_clause().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.group_clause {
             let mut node = Node::GroupClause(v);
             tf.trans(&mut node);
-            //self.group_clause = Some(node.into_group_clause().unwrap().visit(tf));
             node.into_group_clause().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.having_clause {
             let mut node = Node::HavingClause(v);
             tf.trans(&mut node);
-            //self.having_clause = Some(node.into_having_clause().unwrap().visit(tf));
             node.into_having_clause().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.window_clause {
             let mut node = Node::WindowClause(v);
             tf.trans(&mut node);
-            //self.window_clause = Some(node.into_window_clause().unwrap().visit(tf));
             node.into_window_clause().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.order_clause {
             let mut node = Node::OrderClause(v);
             tf.trans(&mut node);
-            //self.order_clause = Some(node.into_order_clause().unwrap().visit(tf));
             node.into_order_clause().unwrap().visit(tf);
         }
 
         if let Some(v) = &mut self.limit_clause {
             let mut node = Node::LimitClause(v);
             tf.trans(&mut node);
-            //self.limit_clause = Some(node.into_limit_clause().unwrap().visit(tf));
             node.into_limit_clause().unwrap().visit(tf);
         }
-
-        //let mut new_locks = Vec::with_capacity(self.lock_clauses.len());
 
         for v in self.lock_clauses.iter_mut() {
             let mut node = Node::LockClause(v);
             tf.trans(&mut node);
-            //let new_node = node.into_lock_clause().unwrap();
             node.into_lock_clause().unwrap().visit(tf);
-            //new_locks.push(new_node.visit(tf))
         }
-
-        //if !new_locks.is_empty() {
-        //    self.lock_clauses = new_locks
-        //}
 
         if let Some(union) = &mut self.union_query {
             let mut node = Node::SelectStmt(union);
             tf.trans(&mut node);
-            //let new_node = node.into_select_stmt().unwrap().visit(tf);
             node.into_select_stmt().unwrap().visit(tf);
-            //self.union_query = Some(Box::new(new_node));
         }
-
-        //self.clone()
     }
 }
 
@@ -382,8 +343,6 @@ impl Items {
 
 impl Visitor for Items {
     fn visit<T: Transformer>(&mut self, tf: &mut T) {
-        //let mut new_items = Vec::with_capacity(self.items.len());
-
         for v in self.items.iter_mut() {
             let mut node = Node::Item(v);
             let is_skip = tf.trans(&mut node);
@@ -391,17 +350,11 @@ impl Visitor for Items {
 
             if is_skip {
                 tf.complete(&mut Node::Item(new_node));
-                //new_items.push(new_node.clone());
                 continue;
             }
             
-            //new_items.push(new_node.visit(tf));
             new_node.visit(tf);
         }
-
-        //self.items = new_items;
-
-        //self.clone()
     }
 }
 
@@ -432,9 +385,8 @@ impl Visitor for Item {
             Self::TableWild(wild) => {
                 let mut node = Node::TableWild(wild);
                 tf.trans(&mut node);
-                //let new_node = node.into_table_wild().unwrap();
+                
                 node.into_table_wild().unwrap().visit(tf);
-                //Item::TableWild(new_node.visit(tf))
             }
             Self::ItemExpr(item) => {
                 let mut node = Node::ItemExpr(item);
@@ -442,10 +394,8 @@ impl Visitor for Item {
                 let new_node = node.into_item_expr().unwrap();
                 if is_skip {
                     tf.complete(&mut Node::ItemExpr(new_node));
-                    //return Item::ItemExpr(Box::new(new_node.clone()));
                     return
                 }
-                //Item::ItemExpr(Box::new(new_node.visit(tf)))
                 new_node.visit(tf);
             }
         }
@@ -503,12 +453,8 @@ impl Visitor for ItemExpr {
     fn visit<T: Transformer>(&mut self, tf: &mut T) {
         let mut node = Node::Expr(&mut self.expr);
         tf.trans(&mut node);
-
-        //let new_node = node.into_expr().unwrap().visit(tf);
+        
         node.into_expr().unwrap().visit(tf);
-        //self.expr = new_node;
-
-        //self.clone()
     }
 }
 
@@ -1955,10 +1901,7 @@ impl Visitor for FieldCharType {
         let mut node = Node::CharsetOrBinary(&mut self.opt);
         tf.trans(&mut node);
 
-        //self.opt = node.into_charset_or_binary().unwrap().visit(tf);
         node.into_charset_or_binary().unwrap().visit(tf);
-
-        //self.clone()
     }
 }
 

--- a/pisa-proxy/parser/mysql/src/ast/tcl.rs
+++ b/pisa-proxy/parser/mysql/src/ast/tcl.rs
@@ -64,12 +64,7 @@ impl Start {
 }
 
 impl Visitor for Start {
-    fn visit<T>(&mut self, _tf: &mut T) -> Self
-    where
-        T: Transformer,
-    {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) {}
 }
 
 #[derive(Debug, Clone)]
@@ -94,12 +89,7 @@ impl Commit {
 }
 
 impl Visitor for Commit {
-    fn visit<T>(&mut self, _tf: &mut T) -> Self
-    where
-        T: Transformer,
-    {
-        self.clone()
-    }
+    fn visit<T>(&mut self, _tf: &mut T) {}
 }
 
 #[derive(Debug, Clone)]
@@ -136,12 +126,7 @@ impl Rollback {
 }
 
 impl Visitor for Rollback {
-    fn visit<T>(&mut self, _tf: &mut T) -> Self
-    where
-        T: Transformer,
-    {
-        self.clone()
-    }
+    fn visit<T: Transformer>(&mut self, _tf: &mut T) {}
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Signed-off-by: xuanyuan300 <xuanyuan300@gmail.com>

<!--
Thank you for contributing to Pisanix!

If you haven't already, please read Pisanix's [CONTRIBUTING](../CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed:
1. Optimize ast visitor for parser to avoid  unneed `clone` method.
