### PR TITLE
fix : we should set password to vec[0] when password is empty in Client Auth Plugin: caching_sha2_password

### DIFF
--- a/pisa-proxy/protocol/mysql/src/util.rs
+++ b/pisa-proxy/protocol/mysql/src/util.rs
@@ -69,7 +69,7 @@ pub fn calc_password(scramble: &[u8], password: &[u8]) -> Vec<u8> {
 // calc_caching_sha2password: Hash password using MySQL 8+ method (SHA256)
 pub fn calc_caching_sha2password(scramble: &[u8], password: &[u8]) -> Vec<u8> {
     if password.is_empty() {
-        return vec![];
+        return vec![0];
     }
 
     let mut crypt = crypto::sha2::Sha256::new();


### PR DESCRIPTION
### fix empty password login issue at caching_sha2_password, or it will fail to connect to empty password backend.

according to MySQL source code `sql/auth/sha2_password.cc caching_sha2_password_authenticate`, empty password should be set to '\0'

What's Changed:

modify calc_caching_sha2password code to correctly handle empty password

when database has empty password, current calc_caching_sha2password cannot handle it correctly. we should set to vec![0] instead of vec![]

