### PR TITLE
feat(CircuitBreak regex case_insensitive match config)

### DIFF
--- a/pisa-proxy/examples/example-config.toml
+++ b/pisa-proxy/examples/example-config.toml
@@ -64,9 +64,11 @@ duration = 333
 
 [[proxy.config.plugin.circuit_break]]
 regex = ["111"]
+case_insensitive = false
 
 [[proxy.config.plugin.circuit_break]]
 regex = ["222"]
+case_insensitive = false
 
 # 后端数据源配置
 [mysql]

--- a/pisa-proxy/plugin/src/config.rs
+++ b/pisa-proxy/plugin/src/config.rs
@@ -34,4 +34,10 @@ pub struct ConcurrencyControl {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CircuitBreak {
     pub regex: Vec<String>,
+    #[serde(default = "default_as_false")]
+    pub case_insensitive: bool,
+}
+
+fn default_as_false() -> bool {
+    false
 }

--- a/pisa-proxy/plugin/src/tests/mod.rs
+++ b/pisa-proxy/plugin/src/tests/mod.rs
@@ -35,7 +35,7 @@ fn test_chain_concurrency_control_and_circuit_break() {
     }];
 
     let circuit_break_config =
-        vec![config::CircuitBreak { regex: vec![String::from(r"[A-Za-z]+")] }];
+        vec![config::CircuitBreak { regex: vec![String::from(r"[A-Za-z]+")], case_insensitive: false }];
 
     let mut wrap_svc = ServiceBuilder::new()
         .with_layer(ConcurrencyControlLayer::new(concurrency_control_config))


### PR DESCRIPTION
### add case_insensitive option to CircuitBreak regex config

it is friendly to provide case_insensitive option to `proxy.config.plugin.circuit_break` 

```
[[proxy.config.plugin.circuit_break]]
regex = ["111", "^SELECT .* FOR UPDATE"]
case_insensitive = true
```

Tests 

- Unit test(done)